### PR TITLE
Add `upgrade` command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "release"]
+	path = release
+	url = ./release

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,7 @@ test: freight.lua $(OBJECTS)
 freight/version.lua: .FORCE
 .FORCE:
 .PHONY: .FORCE
+
+release: bin/freight ./scripts/release
+	./scripts/release $<
+.PHONY: release

--- a/compat.yue
+++ b/compat.yue
@@ -56,6 +56,8 @@ export apply_compat = ->
     rc = os.execute table.concat args, ' '
     rc == 0
 
+  bit.lshift ??= bit.blshift
+
 export test_compat = ->
   if not compat_applied
     error 'call apply_compat before testing compat'

--- a/compat.yue
+++ b/compat.yue
@@ -22,6 +22,22 @@ export apply_compat = ->
   os.rename ??= (src, dest) ->
     fs.move src, dest
 
+  if not fs?
+    global fs = {}
+
+  fs.makeDir ??= (path) ->
+    os.execute "mkdir -p '#{path}'"
+
+  if not shell?
+    global shell = {}
+
+  shell.execute ??= (...) ->
+    for i = 1, select '#', ...
+      assert 'string' == type select i, ...
+
+    args = [ "'#{arg}'" for arg in *{ 'luajit', ... } ]
+    os.execute table.concat args, ' '
+
 export test_compat = ->
   if not compat_applied
     error 'call apply_compat before testing compat'

--- a/compat.yue
+++ b/compat.yue
@@ -1,12 +1,20 @@
 local *
 
+detect_host = ->
+  if collectgarbage?
+    'native'
+  else
+    'minecraft'
+export HOST = detect_host!
+export LUA = 'luajit'
+
 compat_applied = false
 export apply_compat = ->
   compat_applied = true
 
   os.tmpname ??= ->
     while true
-      f = ".lua_#{'%x'\format math.random 1, 100000}"
+      f = "lua_#{'%x'\format math.random 1, 100000}"
       with? io.open f, 'r'
         \close!
         continue
@@ -22,11 +30,20 @@ export apply_compat = ->
   os.rename ??= (src, dest) ->
     fs.move src, dest
 
+  os.exit ??= (code) ->
+    error "EXIT(#{code})"
+
   if not fs?
     global fs = {}
 
   fs.makeDir ??= (path) ->
     os.execute "mkdir -p '#{path}'"
+
+  fs.getFreeSpace ??= (path) ->
+    1000000
+
+  fs.getCapacity ??= (path) ->
+    1000000
 
   if not shell?
     global shell = {}
@@ -35,8 +52,9 @@ export apply_compat = ->
     for i = 1, select '#', ...
       assert 'string' == type select i, ...
 
-    args = [ "'#{arg}'" for arg in *{ 'luajit', ... } ]
-    os.execute table.concat args, ' '
+    args = [ "'#{arg}'" for arg in *{ LUA, ... } ]
+    rc = os.execute table.concat args, ' '
+    rc == 0
 
 export test_compat = ->
   if not compat_applied
@@ -59,6 +77,11 @@ export test_compat = ->
         with? io.open TEST_FILE, 'r'
           \close!
           error "expected test file '#{TEST_FILE}' to have been removed after calling os.remove"
+    * name: 'HOST is unchanged'
+      check: ->
+        host = detect_host!
+        if HOST != host
+          error "host detection heuristic changed"
   failed = false
   for test in *tests
     try

--- a/docs/marshal-sm.dot
+++ b/docs/marshal-sm.dot
@@ -1,6 +1,6 @@
 #!/usr/bin/sfdp
 digraph {
-	label = "controller state machine"
+	label = "marshal state machine"
 	bgcolor = black // 313244
 	color = white
 	node [

--- a/freight.yue
+++ b/freight.yue
@@ -32,8 +32,6 @@ main = (raw_args) ->
   spec.set_log_verbosity args.verbose
 
   if args.test?
-    detect_and_use_monitor!
-
     skip_minecraft_tests = args.test.no_minecraft
     run_tests args.test.filter
   else if args.start?
@@ -60,7 +58,12 @@ spec.spec ->
       test_compat!
 
 args = {...}
+ok = true
 try
   main args
 catch err
-  print debug.traceback err
+  if err != 'EXIT(0)'
+    print debug.traceback err
+    ok = false
+if not ok
+  os.exit 1

--- a/freight.yue
+++ b/freight.yue
@@ -19,6 +19,7 @@ disable = require 'freight.disable.main'
 enable = require 'freight.enable.main'
 init = require 'freight.init.main'
 start = require 'freight.start.main'
+upgrade = require 'freight.upgrade.main'
 
 global skip_minecraft_tests = false
 
@@ -46,6 +47,8 @@ main = (raw_args) ->
     enable.main args.enable
   else if args.disable?
     disable.main args.disable
+  else if args.upgrade?
+    upgrade.main args.upgrade
   else
     error 'internal error: no command recognised'
 

--- a/freight/args.yue
+++ b/freight/args.yue
@@ -28,3 +28,4 @@ export class Args
       \add (require 'freight.enable.main').subcommand
       \add (require 'freight.init.main').subcommand
       \add (require 'freight.start.main').subcommand
+      \add (require 'freight.upgrade.main').subcommand

--- a/freight/config.yue
+++ b/freight/config.yue
@@ -22,7 +22,7 @@ export config = F '() -> ?{}', ->
   cached_config
 
 exists = F '(string) -> boolean', (path) ->
-  with? io.open CONFIG_FILE, 'r'
+  with? io.open path, 'r'
     assert \close!
     return true
   false

--- a/freight/data/queue.yue
+++ b/freight/data/queue.yue
@@ -17,8 +17,6 @@ export class Queue
     @back += 1
 
   dequeue: F '() => ?any', =>
-    import repr from require 'spec'
-    print repr @
     with? @entries[@front]
       @entries[@front] = nil
       @front += 1

--- a/freight/enable/main.yue
+++ b/freight/enable/main.yue
@@ -29,5 +29,4 @@ export main = F '({}) -> <>', (args) ->
 export _startup_script = [[
 shell.run('set motd.enable false')
 shell.run('freight start')
-shell.exit()
 ]]

--- a/freight/execute.yue
+++ b/freight/execute.yue
@@ -8,7 +8,6 @@ export execute = F '(string, string...) -> boolean', (prog, ...) ->
   for cmd_part in *cmd_parts
     if cmd_part\match '["\']'
       error "cannot execute #{prog}: argument '#{cmd_part}' invalid"
-  print "running #{table.concat cmd_parts, ' '}"
 
   switch HOST
     when 'native'

--- a/freight/execute.yue
+++ b/freight/execute.yue
@@ -1,0 +1,36 @@
+local *
+
+import HOST, LUA from require 'compat'
+import F from require 'quicktype'
+
+export execute = F '(string, string...) -> boolean', (prog, ...) ->
+  cmd_parts = { prog, ... }
+  for cmd_part in *cmd_parts
+    if cmd_part\match '["\']'
+      error "cannot execute #{prog}: argument '#{cmd_part}' invalid"
+  print "running #{table.concat cmd_parts, ' '}"
+
+  switch HOST
+    when 'native'
+      execute_native prog, ...
+    when 'minecraft'
+      execute_minecraft prog, ...
+    else
+      error "internal error: unknown host #{HOST}"
+
+execute_native = F '(string, string...) -> boolean', (...) ->
+  if _VERSION == 'Lua 5.1'
+    rc = os.execute table.concat { LUA, ... }, ' '
+    return rc == 0
+
+  -- NB: The following doesn't work on luajit as \close! always returns true.
+  cmd = table.concat { LUA, ... }, ' '
+  local ok
+  with assert io.popen cmd
+    \read '*a' -- Await completion
+    ok, _, _ = \close!
+  ok ?? false
+
+execute_minecraft = F '(string, string...) -> boolean', (...) ->
+  rc = shell.execute ...
+  rc

--- a/freight/init/main.yue
+++ b/freight/init/main.yue
@@ -17,16 +17,16 @@ export subcommand = with Subcommand 'init'
   \add with Param 'instance-type'
     \description 'the type of instance to initialise'
     \options
-      * 'controller'
+      * 'display'
       * 'factory'
       * 'ledger'
-      * 'display'
+      * 'marshal'
 
 default_config_by_type =
-  controller: (require 'freight.controller.main').default_config
   display: (require 'freight.display.main').default_config
   factory: (require 'freight.factory.main').default_config
   ledger: (require 'freight.ledger.main').default_config
+  marshal: (require 'freight.marshal.main').default_config
 
 export main = F '({}) -> <>', (args) ->
   default_config = default_config_by_type[args.instance_type]

--- a/freight/marshal/main.yue
+++ b/freight/marshal/main.yue
@@ -28,6 +28,8 @@ export main = F '({}) -> <>', (config) ->
   with Marshal config, uplink, upgrade_listener
     \run!
 
+STEP_INTERVAL = 60
+
 declare_type 'Network', [[{
   name: string,
   factories: [Factory],
@@ -57,8 +59,8 @@ class Marshal
       \build!
 
   run: F '(?StateMachine) => !', (state=@@state_machine!) =>
-    parallel.waitForAny @\run_steps,
-      @upgrade_listener\listen,
+    parallel.waitForAny @upgrade_listener\listen,
+      @\run_steps,
 
   run_steps: F '() => !', =>
     @i = 1
@@ -68,4 +70,4 @@ class Marshal
   step: F '() => <>', =>
     print @i
     @i += 1
-    os.sleep 1
+    os.sleep STEP_INTERVAL

--- a/freight/marshal/main.yue
+++ b/freight/marshal/main.yue
@@ -7,7 +7,7 @@ import toml_parse from require 'freight.toml'
 import declare_type, F from require 'quicktype'
 
 export default_config = [=[
-[controller]
+[marshal]
 
 [[networks]]
 name = 'mainline'
@@ -15,14 +15,14 @@ description = 'default train network'
 ]=]
 
 export main = F '({}) -> <>', (config) ->
-  log -> 'starting controller'
+  log -> 'starting marshal'
 
   state = nil
   with? io.open '.freight-state.toml'
     state = toml_parse assert \read '*a'
     assert \close!
 
-  with Controller config, Uplink!
+  with Marshal config, Uplink!
     \run!
 
 declare_type 'Network', [[{
@@ -38,7 +38,7 @@ declare_type 'Train', [[{
   state: StateMachine,
 }]]
 
-class Controller
+class Marshal
   new: F '({}, Uplink) => <>', (@config, @uplink) =>
 
   @state_machine: F '() => StateMachine', =>

--- a/freight/marshal/main.yue
+++ b/freight/marshal/main.yue
@@ -2,6 +2,7 @@ local *
 
 import log from require 'freight.logger'
 import Uplink from require 'freight.peripheral.uplink'
+import UpgradeListener from require 'freight.upgrade.listener'
 import StateMachineBuilder, StateSpec from require 'freight.state'
 import toml_parse from require 'freight.toml'
 import declare_type, F from require 'quicktype'
@@ -22,7 +23,9 @@ export main = F '({}) -> <>', (config) ->
     state = toml_parse assert \read '*a'
     assert \close!
 
-  with Marshal config, Uplink!
+  uplink = Uplink!
+  upgrade_listener = UpgradeListener config, uplink
+  with Marshal config, uplink, upgrade_listener
     \run!
 
 declare_type 'Network', [[{
@@ -39,7 +42,7 @@ declare_type 'Train', [[{
 }]]
 
 class Marshal
-  new: F '({}, Uplink) => <>', (@config, @uplink) =>
+  new: F '({}, Uplink, UpgradeListener) => <>', (@config, @uplink, @upgrade_listener) =>
 
   @state_machine: F '() => StateMachine', =>
     StateMachineBuilder!
@@ -54,6 +57,10 @@ class Marshal
       \build!
 
   run: F '(?StateMachine) => !', (state=@@state_machine!) =>
+    parallel.waitForAny @\run_steps,
+      @upgrade_listener\listen,
+
+  run_steps: F '() => !', =>
     @i = 1
     while true
       @step!

--- a/freight/peripheral/uplink.yue
+++ b/freight/peripheral/uplink.yue
@@ -20,6 +20,10 @@ declare_type 'Uplink', [[{
 }]]
 export class Uplink
   new: F '(?UplinkBackend) => <>', (@backend=MinecraftBackend!) =>
+    @deaf = false
+
+  deafen: F '() => <>', =>
+    @deaf = true
 
   broadcast: F '(Packet) => <>', (message) =>
     @backend\broadcast message, message\protocol!
@@ -42,6 +46,8 @@ export class Uplink
     protocol_filter = message_type?::protocol!
     while true
       id, message, protocol = @backend\receive protocol_filter, timeout
+      if @deaf
+        continue
 
       if not id?
         return nil, TIMEOUT

--- a/freight/peripheral/uplink.yue
+++ b/freight/peripheral/uplink.yue
@@ -114,8 +114,10 @@ export class TestUplinkBackend
     @receive = F '(?string, ?number) => <?number, any, ?string>', receive
     @broadcast = F '(any, ?string) => <>', broadcast
 
-declare_type 'IdempotenceToken', '{}'
-export class IdempotenceToken
+declare_type 'IdempotenceToken', 'number'
+IDEMP_TOK_MAX = bit.lshift 1, 30
+export IdempotenceToken = F '() -> IdempotenceToken', ->
+  math.random 1, IDEMP_TOK_MAX
 
 spec ->
   import describe, expect_that, it, matchers from require 'spec'

--- a/freight/peripheral/uplink.yue
+++ b/freight/peripheral/uplink.yue
@@ -36,7 +36,7 @@ export class Uplink
     @_receive_from from_id, message_type, opts
 
   _receive_from: F '(?number, ?Packet, ?UplinkReceiveOpts) => <?number, Packet|TIMEOUT>', (from_id, message_type, opts={}) =>
-    {:timeout=5} = opts
+    {:timeout} = opts
 
     local id, message, protocol
     protocol_filter = message_type?::protocol!

--- a/freight/peripheral/uplink.yue
+++ b/freight/peripheral/uplink.yue
@@ -3,7 +3,7 @@ local *
 import F, declare_type, declare_singleton_type from require 'quicktype'
 import spec from require 'spec'
 
-TIMEOUT = <tostring>: => "Timeout"
+export TIMEOUT = <tostring>: => "Timeout"
 declare_singleton_type TIMEOUT
 
 declare_type 'UplinkBackend', [[{

--- a/freight/start/main.yue
+++ b/freight/start/main.yue
@@ -4,10 +4,10 @@ import Flag, Subcommand from require 'clap'
 import config from require 'freight.config'
 import F from require 'quicktype'
 
-controller = require 'freight.controller.main'
 display = require 'freight.display.main'
 factory = require 'freight.factory.main'
 ledger = require 'freight.ledger.main'
+marshal = require 'freight.marshal.main'
 
 export subcommand = with Subcommand 'start'
   \description 'start this freight instance'
@@ -22,8 +22,8 @@ export main = F '({}) -> <>', (args) ->
     print 'cannot start freight: config missing\ntry running `freight init <instance-type>` first'
     return
 
-  to_spam = if cfg.controller?
-    -> controller.main cfg
+  to_spam = if cfg.marshal?
+    -> marshal.main cfg
   else if cfg.display?
     -> display.main cfg
   else if cfg.factory?

--- a/freight/start/main.yue
+++ b/freight/start/main.yue
@@ -2,6 +2,8 @@ local *
 
 import Flag, Subcommand from require 'clap'
 import config from require 'freight.config'
+import Uplink from require 'freight.peripheral.uplink'
+import UpgradeMonitor from require 'freight.upgrade.monitor'
 import F from require 'quicktype'
 
 display = require 'freight.display.main'
@@ -21,6 +23,10 @@ export main = F '({}) -> <>', (args) ->
   if not cfg?
     print 'cannot start freight: config missing\ntry running `freight init <instance-type>` first'
     return
+
+  with UpgradeMonitor cfg, Uplink!
+    if \upgrade_available!
+      \upgrade_now!
 
   to_spam = if cfg.marshal?
     -> marshal.main cfg

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -27,60 +27,6 @@ export class Instigator using Tester
     if @await_reboot_request!
       @reboot!
 
-  -- prime_local: F '(string) => <boolean, ?string>', (release) =>
-  --   log -> 'priming local...'
-  --   if not @fs\exists TMP_DIR
-  --     @fs\mkdir TMP_DIR
-  --   @fs\write "#{TMP_DIR}/freight", release
-  --   true, nil
-
-  -- prepare_remotes: F '({number->string}, string) => <boolean, ?string>', (remotes, release) =>
-  --   log -> 'preparing remote instances'
-  --
-  --   idemp_tok = IdempotenceToken!
-  --   @uplink\broadcast PrepareUpgradeRequest idemp_tok, release
-  --   responses = @collect_responses 1, PrepareUpgradeResponse, F '(Packet) -> boolean', (packet) ->
-  --     packet.idemp_tok == idemp_tok
-  --
-  --   true, nil
-
-  -- get_remotes: F '() => {number -> string}', =>
-  --   log -> 'finding remotes...'
-  --
-  --   idemp_tok = IdempotenceToken!
-  --   @uplink\broadcast DeclareSelfRequest idemp_tok
-  --   responses = @collect_responses 1, DeclareSelfResponse, F '(Packet) -> boolean', (packet) ->
-  --     packet.idemp_tok == idemp_tok
-  --
-  --   { from_id, packet for { :from_id, packet: { :name } } in *responses }
-
-  -- collect_responses: F '(number, Packet, (Packet) -> boolean) => [Packet]', (packet_type, window_seconds, filter) =>
-  --   with {}
-  --     abort = false
-  --     parallel.waitForAny
-  --       * ->
-  --         os.sleep window_seconds
-  --       * ->
-  --         while not abort
-  --           from_id, packet_or_error = @uplink\receive_from_any packet_type
-  --           if not from_id?
-  --             if packet_or_error == TIMEOUT
-  --               continue
-  --             error packet_or_error
-  --
-  --           if filter? and not filter packet_or_error
-  --             continue
-  --           [] = :from_id, packet: packet_or_error
-  --     abort = true
-
-  -- transition_local: F '() => <boolean, ?string>', =>
-  --   local err
-  --   try
-  --     @fs\move "#{TMP_DIR}/freight", 'freight'
-  --   catch err2
-  --     err = err2
-  --   not err?, err
-
   bump_marshal: F '(Release) => <>', (release) =>
     log -> 'bumping marshal...'
     @uplink\broadcast MarshalBumpRelease release

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -110,48 +110,6 @@ spec ->
   import describe, expect_that, it, matchers from require 'spec'
   import deep_eq, errors, matches from matchers
 
-  -- class TestBinarySourceBackend
-  --   new: F '({string->string}) => <>', (@files) =>
-  --
-  --   get_file: F '(string) => <?string, ?string>', (file) =>
-  --     content = @files[file]
-  --     if content?
-  --       content, nil
-  --     else
-  --       nil, "no such file: #{file}"
-  --
-  -- class TestFSBackend
-  --   new: F '() => <>', =>
-  --     @fs = {}
-  --
-  --   read: F '(string) -> <?string, ?string>', (file) =>
-  --     entry = @fs[file]
-  --     if not entry?
-  --       return nil, "no such file or directory: #{file}"
-  --     if entry.kind == 'dir'
-  --       return nil, "cannot read directory: #{file}"
-  --     if entry.kind != 'file'
-  --       error "internal error: unknown entry kind: #{entry.kind}"
-  --     dir = file\gmatch '^(.*)/[^/]*'
-  --     if not @fs[dir]?
-  --       return nil, "directory does not yet exist: #{dir}"
-  --     entry.content, nil
-  --
-  --   write: F '(string, string) => <>', (file, content) =>
-  --     @fs[file] = kind: 'file', :content
-  --
-  --   mkdir: F '(string) => <>', (path) =>
-  --     @fs[path] = kind: 'dir'
-  --
-  --   exists: F '(string) => boolean', (path) =>
-  --     @fs[path]?
-  --
-  --   move: F '(string, string) => <>', (src, dest) =>
-  --     if not @fs[src]?
-  --       error "no such file or directory: #{src}"
-  --     @fs[dest] = @fs[src]
-  --     @fs[src] = nil
-
   class TestRebooter
     @marker: 'REBOOTING'
 
@@ -179,9 +137,14 @@ spec ->
           (protocol, id) =>
             i += 1
             1, RebootRequest!, RebootRequest\protocol!
-        broadcast: (packet, protocol) ->
+        broadcast: (packet, protocol) =>
           broadcasted[] = :packet, :protocol
 
       rebooter = TestRebooter!
       upgrader = with Instigator cfg, release, uplink, rebooter
         expect_that (-> \upgrade false), errors matches TestRebooter.marker
+      expect_that sent, deep_eq {}
+      expect_that broadcasted, deep_eq
+        * protocol: 'MarshalBumpRelease'
+          packet:
+            :release

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -1,24 +1,25 @@
 local *
+local MarshalBumpVersion -- TODO(kcza): move me
 
 import log from require 'freight.logger'
 import IdempotenceToken, Packet, TIMEOUT, Uplink from require 'freight.peripheral.uplink'
-import MinecraftRebooter from require 'freight.upgrade.rebooter'
+import MinecraftRebooter, RebootRequest from require 'freight.upgrade.rebooter'
+import Tester from require 'freight.upgrade.tester'
 import F from require 'quicktype'
 import spec from require 'spec'
 
-export class Instigator
+export class Instigator using Tester
   new: F '(?{}, Release, ?Uplink, ?Rebooter) => <>', (@config, @release, @uplink=Uplink!, @rebooter=MinecraftRebooter!) =>
     if config?.marshal?
       error 'cannot instigate upgrade from marshal computer'
 
   upgrade: F '(?boolean) => <>', (prompt=true) =>
-    @test @release
+    assert @test @release
 
     if prompt
       local resp
       while resp != ''
-        print 'upgrade deployed'
-        print 'press [ENTER] to reboot network'
+        print 'press [ENTER] to deploy upgrade'
         resp = io.read '*l'
     @bump_marshal @release
 
@@ -31,24 +32,6 @@ export class Instigator
   --     @fs\mkdir TMP_DIR
   --   @fs\write "#{TMP_DIR}/freight", release
   --   true, nil
-
-  test: F '(Release) => <>', (release) =>
-    log -> 'testing...'
-
-    tmp_path = os.tmpname!
-
-    with assert io.open tmp_path, 'w+'
-      assert \write release.content
-      assert \close!
-
-    ok = shell.execute tmp_path, 'test'
-
-    assert os.remove tmp_path
-
-    print 'ok', ok
-    if not ok
-      print "testing failed"
-      os.exit 1
 
   -- prepare_remotes: F '({number->string}, string) => <boolean, ?string>', (remotes, release) =>
   --   log -> 'preparing remote instances'
@@ -99,29 +82,29 @@ export class Instigator
 
   bump_marshal: F '(Release) => <>', (release) =>
     log -> 'bumping marshal...'
-    @uplink\broadcast BumpVersion release
+    @uplink\broadcast MarshalBumpVersion release
     return
 
   await_reboot_request: F '() => boolean', =>
     log -> 'awaiting reboot request...'
-    ATTEMPTS = 10
-    for i = 1, ATTEMPTS
-      ok, err = @uplink\receive_from_any RebootRequest
+    MAX_ATTEMPTS = 3
+    for i = 1, MAX_ATTEMPTS
+      if i > 1
+        print "awaiting reboot request (attempt #{i}/#{MAX_ATTEMPTS})"
+      ok, err = @uplink\receive_from_any RebootRequest, timeout: 5
       if ok
         return true
       if err != TIMEOUT
         error err
-    print "marshal did not issue reboot after #{ATTEMPTS} attempts listening"
+    print "marshal did not issue reboot request"
     false
 
   reboot: F '() => !', =>
     log -> 'rebooting...'
     @rebooter\reboot!
 
-class BumpVersion extends Packet
+export class MarshalBumpVersion extends Packet
   new: F '(Release) => <>', (@release) =>
-
-class RebootRequest extends Packet
 
 spec ->
   import TestUplinkBackend from require 'freight.peripheral.uplink'
@@ -182,14 +165,7 @@ spec ->
       release =
         file: 'freight'
         version: '9999999999999999'
-        content: [[
-          for i = 1, select('#', ...) do
-            if select(i, ...) == 'test' then
-              return
-            end
-          end
-          error("must pass 'test' to freight")
-        ]]
+        content: 'print("hello, world!")'
 
       sent = {}
       broadcasted = {}

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -11,7 +11,7 @@ import spec from require 'spec'
 export class Instigator using Tester
   new: F '(?{}, Release, ?Uplink, ?Rebooter) => <>', (@config, @release, @uplink=Uplink!, @rebooter=MinecraftRebooter!) =>
     if config?.marshal?
-      error 'cannot instigate upgrade from marshal computer'
+      error 'cannot instigate upgrade from marshal'
 
   upgrade: F '(?boolean) => <>', (prompt=true) =>
     assert @test @release
@@ -19,7 +19,8 @@ export class Instigator using Tester
     if prompt
       local resp
       while resp != ''
-        print 'press [ENTER] to deploy upgrade'
+        print "ready to upgrade to version #{@release.version}"
+        print 'press [ENTER] to deploy'
         resp = io.read '*l'
     @bump_marshal @release
 

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -89,8 +89,7 @@ export class Instigator using Tester
     log -> 'awaiting reboot request...'
     MAX_ATTEMPTS = 3
     for i = 1, MAX_ATTEMPTS
-      if i > 1
-        print "awaiting reboot request (attempt #{i}/#{MAX_ATTEMPTS})"
+      print "awaiting reboot request (attempt #{i}/#{MAX_ATTEMPTS})"
       ok, err = @uplink\receive_from_any RebootRequest, timeout: 5
       if ok
         return true

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -1,5 +1,5 @@
 local *
-local MarshalBumpVersion -- TODO(kcza): move me
+local MarshalBumpRelease
 
 import log from require 'freight.logger'
 import IdempotenceToken, Packet, TIMEOUT, Uplink from require 'freight.peripheral.uplink'
@@ -83,7 +83,7 @@ export class Instigator using Tester
 
   bump_marshal: F '(Release) => <>', (release) =>
     log -> 'bumping marshal...'
-    @uplink\broadcast MarshalBumpVersion release
+    @uplink\broadcast MarshalBumpRelease release
     return
 
   await_reboot_request: F '() => boolean', =>
@@ -100,10 +100,9 @@ export class Instigator using Tester
     false
 
   reboot: F '() => !', =>
-    log -> 'rebooting...'
     @rebooter\reboot!
 
-export class MarshalBumpVersion extends Packet
+export class MarshalBumpRelease extends Packet
   new: F '(Release) => <>', (@release) =>
 
 spec ->

--- a/freight/upgrade/instigator.yue
+++ b/freight/upgrade/instigator.yue
@@ -1,0 +1,212 @@
+local *
+
+import log from require 'freight.logger'
+import IdempotenceToken, Packet, TIMEOUT, Uplink from require 'freight.peripheral.uplink'
+import MinecraftRebooter from require 'freight.upgrade.rebooter'
+import F from require 'quicktype'
+import spec from require 'spec'
+
+export class Instigator
+  new: F '(?{}, Release, ?Uplink, ?Rebooter) => <>', (@config, @release, @uplink=Uplink!, @rebooter=MinecraftRebooter!) =>
+    if config?.marshal?
+      error 'cannot instigate upgrade from marshal computer'
+
+  upgrade: F '(?boolean) => <>', (prompt=true) =>
+    @test @release
+
+    if prompt
+      local resp
+      while resp != ''
+        print 'upgrade deployed'
+        print 'press [ENTER] to reboot network'
+        resp = io.read '*l'
+    @bump_marshal @release
+
+    if @await_reboot_request!
+      @reboot!
+
+  -- prime_local: F '(string) => <boolean, ?string>', (release) =>
+  --   log -> 'priming local...'
+  --   if not @fs\exists TMP_DIR
+  --     @fs\mkdir TMP_DIR
+  --   @fs\write "#{TMP_DIR}/freight", release
+  --   true, nil
+
+  test: F '(Release) => <>', (release) =>
+    log -> 'testing...'
+
+    tmp_path = os.tmpname!
+
+    with assert io.open tmp_path, 'w+'
+      assert \write release.content
+      assert \close!
+
+    ok = shell.execute tmp_path, 'test'
+
+    assert os.remove tmp_path
+
+    print 'ok', ok
+    if not ok
+      print "testing failed"
+      os.exit 1
+
+  -- prepare_remotes: F '({number->string}, string) => <boolean, ?string>', (remotes, release) =>
+  --   log -> 'preparing remote instances'
+  --
+  --   idemp_tok = IdempotenceToken!
+  --   @uplink\broadcast PrepareUpgradeRequest idemp_tok, release
+  --   responses = @collect_responses 1, PrepareUpgradeResponse, F '(Packet) -> boolean', (packet) ->
+  --     packet.idemp_tok == idemp_tok
+  --
+  --   true, nil
+
+  -- get_remotes: F '() => {number -> string}', =>
+  --   log -> 'finding remotes...'
+  --
+  --   idemp_tok = IdempotenceToken!
+  --   @uplink\broadcast DeclareSelfRequest idemp_tok
+  --   responses = @collect_responses 1, DeclareSelfResponse, F '(Packet) -> boolean', (packet) ->
+  --     packet.idemp_tok == idemp_tok
+  --
+  --   { from_id, packet for { :from_id, packet: { :name } } in *responses }
+
+  -- collect_responses: F '(number, Packet, (Packet) -> boolean) => [Packet]', (packet_type, window_seconds, filter) =>
+  --   with {}
+  --     abort = false
+  --     parallel.waitForAny
+  --       * ->
+  --         os.sleep window_seconds
+  --       * ->
+  --         while not abort
+  --           from_id, packet_or_error = @uplink\receive_from_any packet_type
+  --           if not from_id?
+  --             if packet_or_error == TIMEOUT
+  --               continue
+  --             error packet_or_error
+  --
+  --           if filter? and not filter packet_or_error
+  --             continue
+  --           [] = :from_id, packet: packet_or_error
+  --     abort = true
+
+  -- transition_local: F '() => <boolean, ?string>', =>
+  --   local err
+  --   try
+  --     @fs\move "#{TMP_DIR}/freight", 'freight'
+  --   catch err2
+  --     err = err2
+  --   not err?, err
+
+  bump_marshal: F '(Release) => <>', (release) =>
+    log -> 'bumping marshal...'
+    @uplink\broadcast BumpVersion release
+    return
+
+  await_reboot_request: F '() => boolean', =>
+    log -> 'awaiting reboot request...'
+    ATTEMPTS = 10
+    for i = 1, ATTEMPTS
+      ok, err = @uplink\receive_from_any RebootRequest
+      if ok
+        return true
+      if err != TIMEOUT
+        error err
+    print "marshal did not issue reboot after #{ATTEMPTS} attempts listening"
+    false
+
+  reboot: F '() => !', =>
+    log -> 'rebooting...'
+    @rebooter\reboot!
+
+class BumpVersion extends Packet
+  new: F '(Release) => <>', (@release) =>
+
+class RebootRequest extends Packet
+
+spec ->
+  import TestUplinkBackend from require 'freight.peripheral.uplink'
+  import describe, expect_that, it, matchers from require 'spec'
+  import deep_eq, errors, matches from matchers
+
+  -- class TestBinarySourceBackend
+  --   new: F '({string->string}) => <>', (@files) =>
+  --
+  --   get_file: F '(string) => <?string, ?string>', (file) =>
+  --     content = @files[file]
+  --     if content?
+  --       content, nil
+  --     else
+  --       nil, "no such file: #{file}"
+  --
+  -- class TestFSBackend
+  --   new: F '() => <>', =>
+  --     @fs = {}
+  --
+  --   read: F '(string) -> <?string, ?string>', (file) =>
+  --     entry = @fs[file]
+  --     if not entry?
+  --       return nil, "no such file or directory: #{file}"
+  --     if entry.kind == 'dir'
+  --       return nil, "cannot read directory: #{file}"
+  --     if entry.kind != 'file'
+  --       error "internal error: unknown entry kind: #{entry.kind}"
+  --     dir = file\gmatch '^(.*)/[^/]*'
+  --     if not @fs[dir]?
+  --       return nil, "directory does not yet exist: #{dir}"
+  --     entry.content, nil
+  --
+  --   write: F '(string, string) => <>', (file, content) =>
+  --     @fs[file] = kind: 'file', :content
+  --
+  --   mkdir: F '(string) => <>', (path) =>
+  --     @fs[path] = kind: 'dir'
+  --
+  --   exists: F '(string) => boolean', (path) =>
+  --     @fs[path]?
+  --
+  --   move: F '(string, string) => <>', (src, dest) =>
+  --     if not @fs[src]?
+  --       error "no such file or directory: #{src}"
+  --     @fs[dest] = @fs[src]
+  --     @fs[src] = nil
+
+  class TestRebooter
+    @marker: 'REBOOTING'
+
+    reboot: =>
+      error @@marker
+
+  describe 'Instigator', ->
+    it 'instigates valid updates', ->
+      cfg = {}
+      release =
+        file: 'freight'
+        version: '9999999999999999'
+        content: [[
+          for i = 1, select('#', ...) do
+            if select(i, ...) == 'test' then
+              return
+            end
+          end
+          error("must pass 'test' to freight")
+        ]]
+
+      sent = {}
+      broadcasted = {}
+      last_idemp_tok = nil
+      uplink = Uplink TestUplinkBackend
+        send: (id, packet, protocol) =>
+          send[] = :id, :packet, :protocol
+          last_idemp_tok = packet.idemp_tok
+          true
+        receive: do
+          i = 0
+          (protocol, id) =>
+            i += 1
+            1, RebootRequest!, RebootRequest\protocol!
+        broadcast: (packet, protocol) ->
+          broadcasted[] = :packet, :protocol
+
+      rebooter = TestRebooter!
+      upgrader = with Instigator cfg, release, uplink, rebooter
+        expect_that (-> \upgrade false), errors matches TestRebooter.marker

--- a/freight/upgrade/listener.yue
+++ b/freight/upgrade/listener.yue
@@ -1,0 +1,44 @@
+local *
+
+import Packet from require 'freight.peripheral.uplink'
+import MarshalBumpVersion from require 'freight.upgrade.instigator'
+import MinecraftRebooter, RebootRequest from require 'freight.upgrade.rebooter'
+import Tester from require 'freight.upgrade.tester'
+import declare_type, F from require 'quicktype'
+
+declare_type 'UpgradeListenerKind', '"leader"|"follower"'
+
+declare_type 'UpgradeListenerConfig', [[{
+  marshal: ?{},
+}]]
+
+export class UpgradeListener using Tester
+  new: F '(UpgradeListenerConfig, Uplink, ?Rebooter) => <>', (config, @uplink, @rebooter=MinecraftRebooter!) =>
+    @kind = T 'UpgradeListenerKind', if config.marshal?
+      'leader'
+    else
+      'follower'
+
+  listen: F '() => !', =>
+    switch @kind
+      when 'leader'
+        @listen_as_leader!
+      when 'follower'
+        @listen_as_follower!
+      else
+        error "internal error: unknown listener kind '#{@kind}'"
+
+  listen_as_leader: F '() => !', =>
+    while true
+      _, { :release } = @uplink\receive_from_any MarshalBumpVersion
+      ok, err = @test release
+      if not ok
+        print "cannot apply update: #{err}"
+        continue
+      -- TODO(kcza): set the current release version!
+      @uplink\broadcast RebootRequest!
+      @rebooter\reboot!
+
+  listen_as_follower: F '() => !', =>
+    @uplink\receive_from_any RebootRequest!
+    @rebooter\reboot!

--- a/freight/upgrade/listener.yue
+++ b/freight/upgrade/listener.yue
@@ -1,23 +1,28 @@
 local *
 
-import Packet from require 'freight.peripheral.uplink'
+import log from require 'freight.logger'
+import CurrentReleaseRequest, CurrentReleaseResponse from require 'freight.upgrade.monitor'
 import MarshalBumpVersion from require 'freight.upgrade.instigator'
 import MinecraftRebooter, RebootRequest from require 'freight.upgrade.rebooter'
 import Tester from require 'freight.upgrade.tester'
-import declare_type, F from require 'quicktype'
+import VERSION from require 'freight.version'
+import declare_type, F, T from require 'quicktype'
 
+declare_type 'UpgradeListener', [[{
+  listen: () => !,
+}]]
 declare_type 'UpgradeListenerKind', '"leader"|"follower"'
-
 declare_type 'UpgradeListenerConfig', [[{
   marshal: ?{},
 }]]
-
 export class UpgradeListener using Tester
   new: F '(UpgradeListenerConfig, Uplink, ?Rebooter) => <>', (config, @uplink, @rebooter=MinecraftRebooter!) =>
     @kind = T 'UpgradeListenerKind', if config.marshal?
       'leader'
     else
       'follower'
+
+    @_current_release = nil
 
   listen: F '() => !', =>
     switch @kind
@@ -29,16 +34,56 @@ export class UpgradeListener using Tester
         error "internal error: unknown listener kind '#{@kind}'"
 
   listen_as_leader: F '() => !', =>
+    log -> "listening for upgrades as leader"
+    parallel.waitForAny @\listen_for_release_bumps,
+      @\listen_for_release_requests
+
+  listen_for_release_bumps: F '() => !', =>
     while true
-      _, { :release } = @uplink\receive_from_any MarshalBumpVersion
+      _, { :release } = @uplink\receive_from_any MarshalBumpBinary
+      assert os.remove release.file -- TODO(kcza): DANGEROUS! Increase disk space
+
+      if #release.content > fs.getFreeSpace '/'
+        error "cannot upgrade: too little space, need #{#release.content}, but only #{fs.getFreeSpace '/'}/#{fs.getCapacity '/'} available"
+
       ok, err = @test release
       if not ok
         print "cannot apply update: #{err}"
         continue
-      -- TODO(kcza): set the current release version!
+
+      print "bumping release to version #{release.version}"
+      @_current_release = release
+      with assert io.open release.file, 'w+'
+        \write release.content
+        assert \close!
+
+      print "issuing reboot broadcast"
+      @uplink\deafen!
       @uplink\broadcast RebootRequest!
       @rebooter\reboot!
 
+  listen_for_release_requests: F '() => !', =>
+    while true
+      requester_id, _ = @uplink\receive_from_any CurrentReleaseRequest
+      print "sending current release info to ##{requester_id}"
+      @uplink\send CurrentReleaseResponse @current_release
+
+  current_release: F '() => Release', =>
+    if @kind != 'leader'
+      error 'internal error: non-leader requested current release'
+    if @_current_release?
+      return @_current_release
+
+    content = do
+      local content
+      with assert io.open 'freight', 'r'
+        content = assert \read '*a'
+        assert \close!
+      content
+    @_current_release = name: 'freight', version: VERSION, :content
+    @_current_release
+
   listen_as_follower: F '() => !', =>
+    log -> "listening for upgrades as follower"
     @uplink\receive_from_any RebootRequest!
     @rebooter\reboot!

--- a/freight/upgrade/listener.yue
+++ b/freight/upgrade/listener.yue
@@ -40,16 +40,7 @@ export class UpgradeListener using Tester
 
   listen_for_release_bumps: F '() => !', =>
     while true
-      _, pkt = @uplink\receive_from_any MarshalBumpRelease
-
-      import repr from require 'spec'
-      for key in pairs pkt
-        print 'k', key
-      print pkt\protocol!
-
-      {:release} = pkt
-      assert os.remove release.file -- TODO(kcza): DANGEROUS! Increase disk space
-
+      _, { :release } = @uplink\receive_from_any MarshalBumpRelease
       if #release.content > fs.getFreeSpace '/'
         error "cannot upgrade: too little space, need #{#release.content}, but only #{fs.getFreeSpace '/'}/#{fs.getCapacity '/'} available"
 

--- a/freight/upgrade/listener.yue
+++ b/freight/upgrade/listener.yue
@@ -2,7 +2,7 @@ local *
 
 import log from require 'freight.logger'
 import CurrentReleaseRequest, CurrentReleaseResponse from require 'freight.upgrade.monitor'
-import MarshalBumpVersion from require 'freight.upgrade.instigator'
+import MarshalBumpRelease from require 'freight.upgrade.instigator'
 import MinecraftRebooter, RebootRequest from require 'freight.upgrade.rebooter'
 import Tester from require 'freight.upgrade.tester'
 import VERSION from require 'freight.version'
@@ -40,7 +40,14 @@ export class UpgradeListener using Tester
 
   listen_for_release_bumps: F '() => !', =>
     while true
-      _, { :release } = @uplink\receive_from_any MarshalBumpBinary
+      _, pkt = @uplink\receive_from_any MarshalBumpRelease
+
+      import repr from require 'spec'
+      for key in pairs pkt
+        print 'k', key
+      print pkt\protocol!
+
+      {:release} = pkt
       assert os.remove release.file -- TODO(kcza): DANGEROUS! Increase disk space
 
       if #release.content > fs.getFreeSpace '/'
@@ -64,9 +71,9 @@ export class UpgradeListener using Tester
 
   listen_for_release_requests: F '() => !', =>
     while true
-      requester_id, _ = @uplink\receive_from_any CurrentReleaseRequest
+      requester_id, { :idemp_tok } = @uplink\receive_from_any CurrentReleaseRequest
       print "sending current release info to ##{requester_id}"
-      @uplink\send CurrentReleaseResponse @current_release
+      @uplink\send_to requester_id, CurrentReleaseResponse idemp_tok, @current_release!
 
   current_release: F '() => Release', =>
     if @kind != 'leader'
@@ -75,12 +82,11 @@ export class UpgradeListener using Tester
       return @_current_release
 
     content = do
-      local content
       with assert io.open 'freight', 'r'
         content = assert \read '*a'
         assert \close!
       content
-    @_current_release = name: 'freight', version: VERSION, :content
+    @_current_release = T 'Release', file: 'freight', version: VERSION, :content
     @_current_release
 
   listen_as_follower: F '() => !', =>

--- a/freight/upgrade/main.yue
+++ b/freight/upgrade/main.yue
@@ -59,4 +59,3 @@ class ReleaseDownloader
       error 'internal error: no version found in downloaded file'
 
     :file, :version, :content
-

--- a/freight/upgrade/main.yue
+++ b/freight/upgrade/main.yue
@@ -1,0 +1,10 @@
+local *
+
+import Flag, Subcommand from require 'clap'
+import F from require 'quicktype'
+
+export subcommand = with Subcommand 'upgrade'
+  \description 'upgrade all freight versions across all networks'
+
+export main = F '({}) -> <>', (args) ->
+  print 'upgrading!'

--- a/freight/upgrade/main.yue
+++ b/freight/upgrade/main.yue
@@ -13,6 +13,8 @@ export subcommand = with Subcommand 'upgrade'
   \add with Flag 'force'
     \short nil
     \description 'skip version check'
+  \add with Flag 'yes'
+    \description 'skip confirmation'
 
 export main = F '({}) -> <>', (args) ->
   local release
@@ -26,7 +28,7 @@ export main = F '({}) -> <>', (args) ->
     return
 
   with Instigator config!, release
-    \upgrade!
+    \upgrade not args.yes
   return
 
 export TMP_DIR = '.upgrade_tmp'

--- a/freight/upgrade/main.yue
+++ b/freight/upgrade/main.yue
@@ -1,10 +1,60 @@
 local *
 
 import Flag, Subcommand from require 'clap'
-import F from require 'quicktype'
+import config from require 'freight.config'
+import log from require 'freight.logger'
+import Instigator from require 'freight.upgrade.instigator'
+import VERSION from require 'freight.version'
+import declare_type, F from require 'quicktype'
+import spec from require 'spec'
 
 export subcommand = with Subcommand 'upgrade'
   \description 'upgrade all freight versions across all networks'
+  \add with Flag 'force'
+    \short nil
+    \description 'skip version check'
 
 export main = F '({}) -> <>', (args) ->
-  print 'upgrading!'
+  local release
+  RELEASE_REPO_URL = 'https://gitlab.legitcorp.com/kcza/freight/-/raw/master'
+  with ReleaseDownloader RELEASE_REPO_URL
+    release, err = \get_file 'freight'
+    if err?
+      error err
+  if not args.force and release.version <= VERSION
+    print 'already up to date'
+    return
+
+  with Instigator config!, release
+    \upgrade!
+  return
+
+export TMP_DIR = '.upgrade_tmp'
+
+declare_type 'Release', [[{
+  file: string,
+  version: string,
+  content: string,
+}]]
+
+class ReleaseDownloader
+  new: (@release_repo_url) =>
+
+  get_file: F '(string) => Release', (file) =>
+    log -> "getting #{file}..."
+
+    local content
+    with assert http.get "#{@release_repo_url}/#{file}"
+      content = \readAll!
+      \close!
+
+    version = nil
+    for v in content\gmatch [=[VERSION = ['"]([0-9][^'"]*)['"]]=]
+      if version?
+        error 'internal error: multiple versions found in downloaded file'
+      version = v
+    if not version?
+      error 'internal error: no version found in downloaded file'
+
+    :file, :version, :content
+

--- a/freight/upgrade/monitor.yue
+++ b/freight/upgrade/monitor.yue
@@ -2,6 +2,7 @@ local *
 local CurrentReleaseRequest
 local CurrentReleaseResponse
 
+import log from require 'freight.logger'
 import IdempotenceToken, Packet, TIMEOUT from require 'freight.peripheral.uplink'
 import VERSION from require 'freight.version'
 import declare_type, F from require 'quicktype'
@@ -26,6 +27,7 @@ export class UpgradeMonitor
     true
 
   upgrade_now: F '() => !', =>
+    log -> "upgrading to version #{@new_release.version}"
     @uplink\deafen!
     with assert io.open @new_release.file, 'w+'
       \write @new_release.content

--- a/freight/upgrade/monitor.yue
+++ b/freight/upgrade/monitor.yue
@@ -1,0 +1,57 @@
+local *
+local CurrentReleaseRequest
+local CurrentReleaseResponse
+
+import IdempotenceToken, Packet, TIMEOUT from require 'freight.peripheral.uplink'
+import VERSION from require 'freight.version'
+import declare_type, F from require 'quicktype'
+
+declare_type 'UpgradeMonitorConfig', [[{
+  marshal: ?{},
+}]]
+
+export class UpgradeMonitor
+  new: F '(UpgradeMonitorConfig, Uplink) => <>', (config, @uplink) =>
+    @is_marshal = config.marshal?
+    @new_release = nil
+
+  upgrade_available: F '() => boolean', =>
+    if @is_marshal
+      return false
+
+    release = @get_latest_release!
+    if release.version <= VERSION
+      return false
+    @new_release = release
+    true
+
+  upgrade_now: F '() => !', =>
+    @uplink\deafen!
+    with assert io.open @new_release.file, 'w+'
+      \write @new_release.content
+      assert \close!
+    os.reboot!
+
+  get_latest_release: F '() => Release', =>
+    attempt = 0
+    while true
+      attempt += 1
+      if attempt > 1
+        print "getting release from marshal, attempt #{attempt}"
+
+      idemp_tok = IdempotenceToken!
+      @uplink\broadcast CurrentReleaseRequest idemp_tok
+      marshal_id, pkt_or_err = @uplink\receive_from_any CurrentReleaseResponse, timeout: 10
+      if not marshal_id?
+        if pkt_or_err != TIMEOUT
+          print "ignoring error whilst getting update: #{pkt_or_err}"
+      else if pkt_or_err.idemp_tok != idemp_tok
+        continue
+      else
+        return pkt_or_err.release
+
+export class CurrentReleaseRequest extends Packet
+  new: F '(IdempotenceToken) => <>', (@idemp_tok) =>
+
+export class CurrentReleaseResponse extends Packet
+  new: F '(IdempotenceToken, Release) => <>', (@idemp_tok, @release) =>

--- a/freight/upgrade/rebooter.yue
+++ b/freight/upgrade/rebooter.yue
@@ -1,0 +1,12 @@
+local *
+
+import Packet from require 'freight.peripheral.uplink'
+import declare_type, F from require 'quicktype'
+
+declare_type 'Rebooter', [[{
+  reboot: () => !,
+}]]
+
+export class MinecraftRebooter
+  reboot: F '() => <>', =>
+    os.reboot!

--- a/freight/upgrade/rebooter.yue
+++ b/freight/upgrade/rebooter.yue
@@ -1,5 +1,6 @@
 local *
 
+import log from require 'freight.logger'
 import Packet from require 'freight.peripheral.uplink'
 import declare_type, F from require 'quicktype'
 
@@ -9,6 +10,7 @@ declare_type 'Rebooter', [[{
 
 export class MinecraftRebooter
   reboot: F '() => !', =>
+    log -> 'rebooting'
     os.reboot!
 
 export class RebootRequest extends Packet

--- a/freight/upgrade/rebooter.yue
+++ b/freight/upgrade/rebooter.yue
@@ -8,5 +8,7 @@ declare_type 'Rebooter', [[{
 }]]
 
 export class MinecraftRebooter
-  reboot: F '() => <>', =>
+  reboot: F '() => !', =>
     os.reboot!
+
+export class RebootRequest extends Packet

--- a/freight/upgrade/tester.yue
+++ b/freight/upgrade/tester.yue
@@ -1,0 +1,74 @@
+local *
+
+import execute from require 'freight.execute'
+import log from require 'freight.logger'
+import F from require 'quicktype'
+import spec from require 'spec'
+
+export class Tester
+  test: F '(Release) => <boolean, ?string>', (release) =>
+    log -> 'testing...'
+    log ->
+      "writing #{#release.content} bytes into disk with #{fs.getFreeSpace '/'}/#{fs.getCapacity '/'}"
+
+    tmp_path = os.tmpname!
+    with assert io.open tmp_path, 'w+'
+      \write release.content
+      assert \close!
+    write_ok = false
+    with? io.open tmp_path, 'r'
+      write_ok = release.content == \read '*a'
+      assert \close!
+    local testing_ok
+    if write_ok
+      testing_ok = execute tmp_path, 'test'
+    assert os.remove tmp_path
+
+    if not write_ok
+      return false, "cannot test upgrade: could could not write file to disk"
+    if not testing_ok
+      return false, "testing failed"
+    true, nil
+
+spec ->
+  import describe, expect_that, it, matchers from require 'spec'
+  import eq, has_type from matchers
+
+  describe 'Tester', ->
+    it 'accepts valid releases', ->
+      release =
+        file: 'freight'
+        version: '12345'
+        content: [[]]
+
+      ok, err = Tester!\test release
+      expect_that ok, eq true
+      expect_that err, eq nil
+
+    it 'rejects invalid releases', ->
+      release =
+        file: 'freight'
+        version: '12345'
+        content: [[
+          error('MARKER_ERROR')
+        ]]
+
+      ok, err = Tester!\test release
+      expect_that ok, eq false
+      expect_that err, has_type 'string'
+
+    it 'executes the test command', ->
+      release =
+        file: 'frieght'
+        version: '12345'
+        content: [[
+          for i = 1, select('#', ...) do
+            if select(i, ...) == 'test' then
+              return
+            end
+          end
+          error("must pass 'test' to freight")
+        ]]
+      ok, err = Tester!\test release
+      expect_that ok, eq true
+      expect_that err, eq nil

--- a/freight/upgrade/tester.yue
+++ b/freight/upgrade/tester.yue
@@ -8,8 +8,7 @@ import spec from require 'spec'
 export class Tester
   test: F '(Release) => <boolean, ?string>', (release) =>
     log -> 'testing...'
-    log ->
-      "writing #{#release.content} bytes into disk with #{fs.getFreeSpace '/'}/#{fs.getCapacity '/'}"
+    log -> "writing #{#release.content} bytes into disk with #{fs.getFreeSpace '/'}/#{fs.getCapacity '/'} free space"
 
     tmp_path = os.tmpname!
     with assert io.open tmp_path, 'w+'

--- a/freight/version.yue
+++ b/freight/version.yue
@@ -2,7 +2,9 @@ local *
 
 -- TODO(kcza): get version from tag
 
-macro build_date = ->
-  date = os.date '%Y-%m-%d@%H:%M:%S'
-  "\"#{date}\""
-export VERSION = "0.1 (#{$build_date!})"
+macro version = ->
+  build_date = os.date '%Y-%m-%d@%H:%M:%S'
+  "'0.1 (#{build_date})'"
+
+-- NB: versions must be lexicographically ordered.
+export VERSION = $version!

--- a/freight/version.yue
+++ b/freight/version.yue
@@ -1,5 +1,7 @@
 local *
 
+-- TODO(kcza): get version from tag
+
 macro build_date = ->
   date = os.date '%Y-%m-%d@%H:%M:%S'
   "\"#{date}\""

--- a/moonpack.yue
+++ b/moonpack.yue
@@ -121,7 +121,7 @@ class SourceFile
         [] = @fmt_line lineno, line
 
   fmt_line: (lineno, line) =>
-    if line\match '-- [0-9]+$'
+    if line\match '%-%- [0-9]+$'
       "#{line} -- #{@path}:#{lineno}"
     else
       line

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+if [[ ! -d release/ ]]; then
+	mkdir release
+fi
+
+cp $@ release/
+
+pushd release/
+
+git add .
+git commit -S -m "release @$(date +%Y-%m-%d@%H:%M:%S)"
+git push
+
+popd

--- a/spec.yue
+++ b/spec.yue
@@ -656,3 +656,5 @@ export run_tests = (filter) ->
     "#{Test.num_run} checks run"
   if Test.num_failures > 0
     print "#{Test.num_failures} checks failed!"
+    os.exit 1
+  os.exit 0

--- a/spec.yue
+++ b/spec.yue
@@ -657,4 +657,3 @@ export run_tests = (filter) ->
   if Test.num_failures > 0
     print "#{Test.num_failures} checks failed!"
     os.exit 1
-  os.exit 0


### PR DESCRIPTION
This PR allows the user to call `freight upgrade` to download a new freight version and disseminate it to the rest of the network
