### PR TITLE
Lint source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,16 @@ uninstall: scripts/uninstall
 	./$<
 .PHONY: uninstall
 
-test: freight.lua $(OBJECTS)
+test: test_freight test_ylint
+.PHONY: test
+
+test_freight: freight.lua $(OBJECTS)
 	@$(LUA) $< test
-.PHONY: .FORCE
+.PHONY: test_freight
+
+test_ylint: ylint.lua
+	@$(LUA) ylint.lua test
+.PHONY: test_ylint
 
 freight/version.lua: .version.txt
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ bin/%.lua.packed: %.lua $(OBJECTS) moonpack.lua
 	$(LUA) ./moonpack.lua $< -o $@
 .INTERMEDIATE: bin/%.lua.packed
 
-%.lua: %.yue
+%.lua: %.yue ylint.yue
 	yue --target=5.1 -l -s --path="?.yue" $< -o $@
+	@if [ "$<" != "ylint.yue" ]; then yue -e ylint.yue check $<; fi
 	@touch $@
 .PRECIOUS: %.lua
 

--- a/freight.yue
+++ b/freight.yue
@@ -1,18 +1,16 @@
 local *
 
-import apply_compat, test_compat from require 'compat'
+import 'compat' as :apply_compat, :test_compat
 apply_compat!
 
-import declare_type from require 'quicktype'
+import 'quicktype' as :declare_type
 declare_type 'Self', 'some'
 
-import Args from require 'freight.args'
-import run_tests from require 'spec'
-import 'freight.logger'
-import log from require 'freight.logger'
-import 'spec'
-import F from require 'quicktype'
-import detect_and_use_monitor from require 'freight.monitor'
+import 'freight.args' as :Args
+import 'freight.logger' as :log
+import 'freight.monitor' as :detect_and_use_monitor
+import 'quicktype' as :F
+import 'spec' as :run_tests
 
 import 'freight.cmd.clean'
 import 'freight.cmd.disable'
@@ -20,6 +18,8 @@ import 'freight.cmd.enable'
 import 'freight.cmd.init'
 import 'freight.cmd.start'
 import 'freight.cmd.upgrade'
+import 'freight.logger'
+import 'spec'
 
 global skip_minecraft_tests = false
 
@@ -51,7 +51,7 @@ main = (raw_args) ->
     error 'internal error: no command recognised'
 
 spec.spec ->
-  import describe, it from require 'spec'
+  import 'spec' as :describe, :it
 
   describe 'compat', ->
     it 'passes checks', ->

--- a/freight/version.yue
+++ b/freight/version.yue
@@ -14,7 +14,9 @@ export VERSION = $version!
 
 spec ->
   import 'spec_macros' as $
-  import describe, expect_that, it, matchers from require 'spec'
+
+  import 'spec' as :describe, :expect_that, :it, :matchers
+
   import lt from matchers
 
   describe 'version', ->

--- a/goo.yue
+++ b/goo.yue
@@ -1,6 +1,6 @@
 local *
 
-import ArgParser, Subcommand, Param, Flag from require 'clap'
+import 'clap' as :ArgParser, :Flag, :Param, :Subcommand
 
 DEFAULT_FILE_DIVIDER = (os.getenv? 'GOO_DIVIDER') ?? 'XXX---XXX===fdhsavcuyxio4321vdcp1234nhuvd---XXX===XXX'
 

--- a/moonpack.yue
+++ b/moonpack.yue
@@ -1,7 +1,6 @@
 local *
 
-import ArgParser, Flag, Param from require 'clap'
-import spec, run_tests from require 'spec'
+import 'spec' as :run_tests, :spec
 
 main = (args) ->
   args, ok = parse_args args
@@ -152,7 +151,7 @@ _G.fs ??= {
 }
 
 spec ->
-  import describe, it from require 'spec'
+  import 'spec' as :describe, :it
 
   describe 'module_name', ->
     it 'rejects non-lua files', ->

--- a/spec_macros.yue
+++ b/spec_macros.yue
@@ -14,4 +14,4 @@ export macro assert_that = (expr, matcher) ->
     eqs ..= '='
   label = "[#{eqs}[#{expr}]#{eqs}]"
 
-  "require('spec')._expect_that #{label}, #{expr}, #{matcher}"
+  "require('spec')._assert_that #{label}, #{expr}, #{matcher}"

--- a/ylint.yue
+++ b/ylint.yue
@@ -110,7 +110,7 @@ class ImportBlockKind extends ImportBlockCheck
       return
 
     Declare::error with Error 'import block has mixed form'
-      \at block[#block]
+      \at block[1]
 
   is_mixed_form: F '([Line]) => boolean', (block) =>
     form = nil
@@ -151,7 +151,7 @@ class ImportBlockSorted extends ImportBlockCheck
       return
 
     Declare::error with Error 'import block not sorted'
-      \at block[#block]
+      \at block[1]
 
 class ImportForm
   on_line: F '(Line) => <>', (line) =>

--- a/ylint.yue
+++ b/ylint.yue
@@ -11,9 +11,11 @@ main = (args) ->
 
   if args.test?
     run_tests!
-    return
-  if args.check?
-    check args.check
+  else if args.check?
+    ok = check args.check
+    if not ok
+      os.exit 1
+  os.exit 0
 
 parse_args = F '([string]) -> <?{}, boolean>', (args) ->
   parser = with ArgParser 'ylint'
@@ -27,40 +29,36 @@ parse_args = F '([string]) -> <?{}, boolean>', (args) ->
       \description 'run tests'
   parser\parse args
 
-check = F '({}) -> <>', (args) ->
+check = F '({}) -> boolean', (args) ->
   { :file } = args
 
   lines = io.lines file
   errs = run_checks file, lines,
     * ImportForm!
+    -- * ImportStatementsSorted!
+    -- * ImportItemsSorted!
   for err in *errs
     buf = {}
     err\fmt buf
     print table.concat buf
+  #errs == 0
 
 run_checks = F '(string, function, [Check]) -> [Error]', (file, src_lines, checks) ->
-  with {}
-    line_no = 0
-    for src_line in src_lines
-      line_no += 1
-      for check in *checks
-        location = :file, row: line_no
-        line = :location, content: src_line
-
-        new_errs = check\on_line? line
-        if new_errs?
-          for new_err in *new_errs
-            [] = new_err
-
+  line_no = 0
+  for src_line in src_lines
+    line_no += 1
     for check in *checks
-      new_errs = check\on_eof?!
-      if new_errs?
-        for new_err in *new_errs
-          [] = new_err
+      location = :file, row: line_no
+      line = :location, content: src_line
+      check\on_line? line
+
+  for check in *checks
+    new_errs = check\on_eof?!
+  Declare::errs!
 
 declare_type 'Check', [[{
-  on_line: ?(Line) => ?[Error],
-  on_eof: ?() => ?[Error],
+  on_line: ?(Line) => <>,
+  on_eof: ?() => <>,
 }]]
 declare_type 'Line', [[{
   location: Location,
@@ -71,16 +69,44 @@ declare_type 'Location', [[{
   row: number,
 }]]
 
+class Declare
+  @errs: T '() => [Error]', => @_errs
+
+  @_errs: T '[Error]', {}
+
+  @error: F '(Error) => <>', (err) =>
+    @_errs[] = err
+
 class ImportForm
-  on_line: F '(Line) => ?[Error]', (line) =>
+  on_line: F '(Line) => <>', (line) =>
     if not line.content\match '^%s*import'
-      return nil
+      return
     if not line.content\match 'from require'
-      return nil
-    err = with Error 'non-standard import form'
+      return
+    Declare::error with Error 'non-standard import form'
       \at line
-      \suggest [[use form `import 'foo' as :bar]]
-    { err }
+      \help [[use form `import 'foo' as :bar]]
+
+-- class ImportStatementsSorted
+--   new: =>
+--     @current_import_block = T '[Line]', {}
+--
+--   on_line: F '(Line) => <>', (line) =>
+--     if line_is_empty line
+--       return @on_block_end!
+--     if not line\match '^%s*import'
+--       return
+--     @current_import_block[] = line
+--     nil
+--
+--   on_eof: F '() => <>', (line) =>
+--     @on_block_end!
+--
+--   on_block_end: F '() => ?Error', =>
+--     @current_import_block = {}
+--     nil
+
+-- class ImportItemsSorted -- TODO(kcza): complete me!
 
 declare_type 'Error', [[{
   fmt: ({string}) => <>,
@@ -88,11 +114,11 @@ declare_type 'Error', [[{
 class Error
   new: F '(string) => <>', (@message) =>
     @line = T '?Line', nil
-    @suggestion = T '?string', nil
+    @_help = T '?string', nil
 
   at: F '(Line) => <>', (@line) =>
 
-  suggest: F '(string) => <>', (@suggestion) =>
+  help: F '(string) => <>', (@_help) =>
 
   fmt: F '({string}) => <>', (buf) =>
     with buf
@@ -105,10 +131,10 @@ class Error
         [] = @line.content
         [] = '\n  |'
 
-      if @suggestion?
+      if @_help?
         [] = '\n'
-        [] = '  * suggestion: '
-        [] = @suggestion
+        [] = '  * help: '
+        [] = @_help
     return
 
 line_is_empty = F '(Line) -> boolean', (line) ->

--- a/ylint.yue
+++ b/ylint.yue
@@ -36,7 +36,7 @@ check = F '({}) -> boolean', (args) ->
   errs = run_checks file, lines,
     * ImportForm!
     * ImportStatementsSorted!
-    -- * ImportItemsSorted!
+    * ImportItemsSorted!
   for err in *errs
     buf = {}
     err\fmt buf
@@ -125,7 +125,35 @@ class ImportStatementsSorted
 
     @current_import_block = {}
 
--- class ImportItemsSorted -- TODO(kcza): complete me!
+class ImportItemsSorted
+  on_line: F '(Line) => <>', (line) =>
+    if not line.content\match '^%s*import'
+      return
+
+    items = with {}
+      state = 'ignoring'
+      for word in line.content\gmatch '%S+'
+        switch state
+          when 'ignoring'
+            if word == 'as'
+              state = 'collecting'
+          when 'collecting'
+            if ',' == word\sub -1
+              word = word\sub 1, -2
+            [] = word
+
+    sorted = true
+    for i = 2, #items
+      if items[i-1] > items[i]
+        sorted = false
+        break
+    if sorted
+      return
+
+    table.sort items
+    Declare::error with Error 'import items not sorted'
+      \at line
+      \help "try sorting as #{table.concat items, ', '}"
 
 declare_type 'Error', [[{
   fmt: ({string}) => <>,
@@ -138,6 +166,7 @@ class Error
   at: F '(Line) => <>', (@line) =>
 
   help: F '(string) => <>', (@_help) =>
+
   fmt: F '({string}) => <>', (buf) =>
     with buf
       [] = 'warning: '
@@ -211,5 +240,24 @@ spec ->
         message: eq 'import block not sorted'
       $expect_that errs[2], has_fields
         message: eq 'import block not sorted'
+
+  describe 'ImportItemsSorted', ->
+    it 'accepts sorted import items', ->
+      errs = run_check ImportItemsSorted!, 'test.yue', [[
+        import 'asdf' as :a, :b, :c
+      ]]
+      $expect_that errs, deep_eq {}
+
+    it 'rejects unsorted import items', ->
+      errs = run_check ImportItemsSorted!, 'test.yue', [[
+        import 'asdf' as :c, :b, :a
+      ]]
+      $assert_that errs, len eq 1
+      $expect_that errs[1], has_fields
+        message: eq 'import items not sorted'
+        line: has_fields
+          location: has_fields
+            row: eq 1
+
 
 main {...}

--- a/ylint.yue
+++ b/ylint.yue
@@ -35,7 +35,7 @@ check = F '({}) -> boolean', (args) ->
   lines = io.lines file
   errs = run_checks file, lines,
     * ImportForm!
-    -- * ImportStatementsSorted!
+    * ImportStatementsSorted!
     -- * ImportItemsSorted!
   for err in *errs
     buf = {}
@@ -44,6 +44,8 @@ check = F '({}) -> boolean', (args) ->
   #errs == 0
 
 run_checks = F '(string, function, [Check]) -> [Error]', (file, src_lines, checks) ->
+  Declare::reset_errs!
+
   line_no = 0
   for src_line in src_lines
     line_no += 1
@@ -70,9 +72,12 @@ declare_type 'Location', [[{
 }]]
 
 class Declare
-  @errs: T '() => [Error]', => @_errs
-
   @_errs: T '[Error]', {}
+
+  @errs: F '() => [Error]', => @_errs
+
+  @reset_errs: F '() => <>', =>
+    @_errs = {}
 
   @error: F '(Error) => <>', (err) =>
     @_errs[] = err
@@ -87,24 +92,38 @@ class ImportForm
       \at line
       \help [[use form `import 'foo' as :bar]]
 
--- class ImportStatementsSorted
---   new: =>
---     @current_import_block = T '[Line]', {}
---
---   on_line: F '(Line) => <>', (line) =>
---     if line_is_empty line
---       return @on_block_end!
---     if not line\match '^%s*import'
---       return
---     @current_import_block[] = line
---     nil
---
---   on_eof: F '() => <>', (line) =>
---     @on_block_end!
---
---   on_block_end: F '() => ?Error', =>
---     @current_import_block = {}
---     nil
+class ImportStatementsSorted
+  new: =>
+    @current_import_block = T '[Line]', {}
+
+  on_line: F '(Line) => <>', (line) =>
+    if line_is_empty line
+      return @on_block_end!
+    if not line.content\match '^%s*import'
+      return @on_block_end!
+    @current_import_block[] = line
+
+  on_eof: F '() => <>', (line) =>
+    @on_block_end!
+
+  on_block_end: F '() => <>', =>
+    -- Check sorted
+    packages = with {}
+      for line in *@current_import_block
+        [] = line.content\match [[import '([^']*)']]
+
+    sorted = true
+    for i = 2, #packages
+      if packages[i-1] > packages[i]
+        sorted = false
+        break
+    if sorted
+      return
+
+    Declare::error with Error 'import block not sorted'
+      \at @current_import_block[#@current_import_block]
+
+    @current_import_block = {}
 
 -- class ImportItemsSorted -- TODO(kcza): complete me!
 
@@ -119,7 +138,6 @@ class Error
   at: F '(Line) => <>', (@line) =>
 
   help: F '(string) => <>', (@_help) =>
-
   fmt: F '({string}) => <>', (buf) =>
     with buf
       [] = 'warning: '
@@ -132,14 +150,13 @@ class Error
         [] = '\n  |'
 
       if @_help?
-        [] = '\n'
-        [] = '  * help: '
+        [] = '\n  * help: '
         [] = @_help
     return
 
 line_is_empty = F '(Line) -> boolean', (line) ->
   content = line.content
-  (content\match '^%s*$')? or (content\match '^%s*--.*$')?
+  not (content\match '^%s*$')? and not (content\match '^%s*--.*$')?
 
 spec ->
   import 'spec_macros' as $
@@ -168,8 +185,31 @@ spec ->
       $assert_that errs, len eq 1
       $assert_that errs[1], has_fields
         message: eq 'non-standard import form'
-        location: has_fields
-          file: eq file
-          row: eq 1
+        line: has_fields
+          location: has_fields
+            file: eq file
+            row: eq 1
+
+  describe 'ImportStatementsSorted', ->
+    it 'accepts sorted imports', ->
+      errs = run_check ImportStatementsSorted!, 'test.yue', [[
+        import 'a'
+        import 'b'
+      ]]
+      $expect_that errs, deep_eq {}
+
+    it 'rejects unsorted imports', ->
+      errs = run_check ImportStatementsSorted!, 'test.yue', [[
+        import 'b'
+        import 'a'
+
+        import 'd'
+        import 'c'
+      ]]
+      $assert_that errs, len eq 2
+      $expect_that errs[1], has_fields
+        message: eq 'import block not sorted'
+      $expect_that errs[2], has_fields
+        message: eq 'import block not sorted'
 
 main {...}

--- a/ylint.yue
+++ b/ylint.yue
@@ -207,19 +207,65 @@ class Error
 
   fmt: F '({string}) => <>', (buf) =>
     with buf
-      [] = 'warning: '
+      @fmt_stylise buf, 'warning', colour: 'yellow', weight: 'bold'
+      @fmt_stylise buf, ': ', weight: 'bold'
       [] = @message
       if @line?
-        [] = "\n --> #{@line.location.file}:#{@line.location.row}"
-        [] = '\n  |'
-        [] = '\n  | '
-        [] = @line.content
-        [] = '\n  |'
+        [] = '\n '
+        @fmt_stylise buf, '-->', colour: 'blue', weight: 'bold'
+        [] = " #{@line.location.file}:#{@line.location.row}"
+        @fmt_stylise buf, '\n  |', colour: 'blue'
+        @fmt_stylise buf, '\n  | ', colour: 'blue'
+        @fmt_stylise buf, (@line.content\match '^%s*(.*)$'), colour: 'cyan'
+        @fmt_stylise buf, '\n  | ', colour: 'blue'
 
       if @_help?
-        [] = '\n  * help: '
+        [] = '\n  * '
+        @fmt_stylise buf, 'help', colour: 'green', weight: 'bold'
+        @fmt_stylise buf, ': ', weight: 'bold'
         [] = @_help
     return
+
+  fmt_stylise: F '([string], string, Style) => <>', (buf, to_colourise, style) =>
+    with buf
+      colour_index = colour_indices[style.colour ?? 'white']
+      effect_index = effect_indices[style.weight ?? 'normal']
+      [] = "\x1b[#{effect_index};3#{colour_index}m"
+      [] = to_colourise
+      [] = '\x1b[0m'
+    return
+
+colour_indices =
+  black: 0
+  red: 1
+  green: 2
+  yellow: 3
+  blue: 4
+  purple: 5
+  cyan: 6
+  white: 7
+effect_indices =
+  normal: 0
+  bold: 1
+
+declare_type 'Style', [[{
+  colour: ?Colour,
+  weight: ?Weight,
+}]]
+declare_type 'Colour', [[
+  "black"
+  |"red"
+  |"green"
+  |"yellow"
+  |"blue"
+  |"purple"
+  |"cyan"
+  |"white"
+]]
+declare_type 'Weight', [[
+  "normal"
+  |"bold"
+]]
 
 line_is_empty = F '(Line) -> boolean', (line) ->
   content = line.content

--- a/ylint.yue
+++ b/ylint.yue
@@ -1,0 +1,149 @@
+local *
+
+import 'clap' as :ArgParser, :Param, :Subcommand
+import 'quicktype' as :declare_type, :F, :T
+import 'spec' as :run_tests, :spec
+
+main = (args) ->
+  args, ok = parse_args args
+  if not ok
+    return
+
+  if args.test?
+    run_tests!
+    return
+  if args.check?
+    check args.check
+
+parse_args = F '([string]) -> <?{}, boolean>', (args) ->
+  parser = with ArgParser 'ylint'
+    \version '1.0'
+    \description 'a very rudamentary yuescript linter'
+    \add with Subcommand 'check'
+      \description 'check for lint'
+      \add with Param 'file'
+        \description 'file to scan'
+    \add with Subcommand 'test'
+      \description 'run tests'
+  parser\parse args
+
+check = F '({}) -> <>', (args) ->
+  { :file } = args
+
+  lines = io.lines file
+  errs = run_checks file, lines,
+    * ImportForm!
+  for err in *errs
+    buf = {}
+    err\fmt buf
+    print table.concat buf
+
+run_checks = F '(string, function, [Check]) -> [Error]', (file, src_lines, checks) ->
+  with {}
+    line_no = 0
+    for src_line in src_lines
+      line_no += 1
+      for check in *checks
+        location = :file, row: line_no
+        line = :location, content: src_line
+
+        new_errs = check\on_line? line
+        if new_errs?
+          for new_err in *new_errs
+            [] = new_err
+
+    for check in *checks
+      new_errs = check\on_eof?!
+      if new_errs?
+        for new_err in *new_errs
+          [] = new_err
+
+declare_type 'Check', [[{
+  on_line: ?(Line) => ?[Error],
+  on_eof: ?() => ?[Error],
+}]]
+declare_type 'Line', [[{
+  location: Location,
+  content: string,
+}]]
+declare_type 'Location', [[{
+  file: string,
+  row: number,
+}]]
+
+class ImportForm
+  on_line: F '(Line) => ?[Error]', (line) =>
+    if not line.content\match '^%s*import'
+      return nil
+    if not line.content\match 'from require'
+      return nil
+    err = with Error 'non-standard import form'
+      \at line
+      \suggest [[use form `import 'foo' as :bar]]
+    { err }
+
+declare_type 'Error', [[{
+  fmt: ({string}) => <>,
+}]]
+class Error
+  new: F '(string) => <>', (@message) =>
+    @line = T '?Line', nil
+    @suggestion = T '?string', nil
+
+  at: F '(Line) => <>', (@line) =>
+
+  suggest: F '(string) => <>', (@suggestion) =>
+
+  fmt: F '({string}) => <>', (buf) =>
+    with buf
+      [] = 'warning: '
+      [] = @message
+      if @line?
+        [] = "\n --> #{@line.location.file}:#{@line.location.row}"
+        [] = '\n  |'
+        [] = '\n  | '
+        [] = @line.content
+        [] = '\n  |'
+
+      if @suggestion?
+        [] = '\n'
+        [] = '  * suggestion: '
+        [] = @suggestion
+    return
+
+line_is_empty = F '(Line) -> boolean', (line) ->
+  content = line.content
+  (content\match '^%s*$')? or (content\match '^%s*--.*$')?
+
+spec ->
+  import 'spec_macros' as $
+  import 'spec' as :describe, :it, :matchers
+  import deep_eq, eq, has_fields, len from matchers
+
+  run_check = F '(Check, string, string) -> [Error]', (check, file, content) ->
+    if '\n' != content\sub -1
+      content = content .. '\n'
+    lines = content\gmatch '(.-)\n'
+    run_checks file, lines, {check}
+
+  describe 'ImportForm', ->
+    it 'accepts proper form', ->
+      errs = run_check ImportForm!, 'test.yue', [[
+        import 'asdf' as :fdas
+        import "asdf" as :fdas
+      ]]
+      $expect_that errs, deep_eq {}
+
+    it 'rejects improper form', ->
+      file = 'test.yue'
+      errs = run_check ImportForm!, file, [[
+        import fdsa from require 'asdf'
+      ]]
+      $assert_that errs, len eq 1
+      $assert_that errs[1], has_fields
+        message: eq 'non-standard import form'
+        location: has_fields
+          file: eq file
+          row: eq 1
+
+main {...}

--- a/ylint.yue
+++ b/ylint.yue
@@ -34,8 +34,9 @@ check = F '({}) -> boolean', (args) ->
 
   lines = io.lines file
   errs = run_checks file, lines,
+    * ImportBlockKind!
+    * ImportBlockSorted!
     * ImportForm!
-    * ImportStatementsSorted!
     * ImportItemsSorted!
   for err in *errs
     buf = {}
@@ -82,34 +83,63 @@ class Declare
   @error: F '(Error) => <>', (err) =>
     @_errs[] = err
 
-class ImportForm
-  on_line: F '(Line) => <>', (line) =>
-    if not line.content\match '^%s*import'
-      return
-    if not line.content\match 'from require'
-      return
-    Declare::error with Error 'non-standard import form'
-      \at line
-      \help [[use form `import 'foo' as :bar]]
-
-class ImportStatementsSorted
+class ImportBlockCheck
   new: =>
     @current_import_block = T '[Line]', {}
 
   on_line: F '(Line) => <>', (line) =>
     if line_is_empty line
-      return @on_block_end!
+      @_on_block_end!
+      return
     if not line.content\match '^%s*import'
-      return @on_block_end!
+      @_on_block_end!
+      return
     @current_import_block[] = line
 
   on_eof: F '() => <>', (line) =>
-    @on_block_end!
+    @_on_block_end!
 
-  on_block_end: F '() => <>', =>
+  _on_block_end: F '() => <>', =>
+    if #@current_import_block != 0
+      @on_block_end @current_import_block
+    @current_import_block = {}
+
+class ImportBlockKind extends ImportBlockCheck
+  on_block_end: F '([Line]) => <>', (block) =>
+    if not @is_mixed_form block
+      return
+
+    Declare::error with Error 'import block has mixed form'
+      \at block[#block]
+
+  is_mixed_form: F '([Line]) => boolean', (block) =>
+    form = nil
+    for line in *block
+      line_form = if line.content\match 'import .* from require'
+        'import-from-require'
+      else if line.content\match 'import .* from %w+'
+        'import-from-value'
+      else if line.content\match 'import .* as '
+        'import-as'
+      else if line.content\match 'import'
+        'import'
+      else
+        Declare::error with Error 'non-standard import statement'
+          \at line
+          \help "use form `import 'foo' as :bar` or `import bar from foo"
+        return false
+
+      if not form?
+        form = line_form
+      if form != line_form
+        return true
+    false
+
+class ImportBlockSorted extends ImportBlockCheck
+  on_block_end: F '([Line]) => <>', (block) =>
     -- Check sorted
     packages = with {}
-      for line in *@current_import_block
+      for line in *block
         [] = line.content\match [[import '([^']*)']]
 
     sorted = true
@@ -121,9 +151,17 @@ class ImportStatementsSorted
       return
 
     Declare::error with Error 'import block not sorted'
-      \at @current_import_block[#@current_import_block]
+      \at block[#block]
 
-    @current_import_block = {}
+class ImportForm
+  on_line: F '(Line) => <>', (line) =>
+    if not line.content\match '^%s*import'
+      return
+    if not line.content\match 'from require'
+      return
+    Declare::error with Error 'non-standard import form'
+      \at line
+      \help [[use form `import 'foo' as :bar]]
 
 class ImportItemsSorted
   on_line: F '(Line) => <>', (line) =>
@@ -190,7 +228,7 @@ line_is_empty = F '(Line) -> boolean', (line) ->
 spec ->
   import 'spec_macros' as $
   import 'spec' as :describe, :it, :matchers
-  import deep_eq, eq, has_fields, len from matchers
+  import deep_eq, each_value, eq, has_fields, len from matchers
 
   run_check = F '(Check, string, string) -> [Error]', (check, file, content) ->
     if '\n' != content\sub -1
@@ -219,16 +257,16 @@ spec ->
             file: eq file
             row: eq 1
 
-  describe 'ImportStatementsSorted', ->
+  describe 'ImportBlockSorted', ->
     it 'accepts sorted imports', ->
-      errs = run_check ImportStatementsSorted!, 'test.yue', [[
+      errs = run_check ImportBlockSorted!, 'test.yue', [[
         import 'a'
         import 'b'
       ]]
       $expect_that errs, deep_eq {}
 
     it 'rejects unsorted imports', ->
-      errs = run_check ImportStatementsSorted!, 'test.yue', [[
+      errs = run_check ImportBlockSorted!, 'test.yue', [[
         import 'b'
         import 'a'
 
@@ -259,5 +297,28 @@ spec ->
           location: has_fields
             row: eq 1
 
+  describe 'ImportBlockKind', ->
+    it 'accepts homogenous blocks', ->
+      errs = run_check ImportBlockKind!, 'test.yue', [[
+        import 'a'
+
+        import 'b' as :c
+
+        import d from e
+      ]]
+      $expect_that errs, deep_eq {}
+
+    it 'rejects hetrogenous blocks', ->
+      errs = run_check ImportBlockKind!, 'test.yue', [[
+        import 'a'
+        import 'b' as :c
+      ]]
+      errs2 = run_check ImportBlockKind!, 'test.yue', [[
+        import 'b' as :c
+        import d from e
+      ]]
+      $expect_that errs, len eq 1
+      $expect_that errs, each_value has_fields
+        message: eq 'import block has mixed form'
 
 main {...}


### PR DESCRIPTION
This PR adds a very rudamentary linter, `ylint`, which is run on builds.

The new linter does not parse the source files, but rather goes through the given file line-by-line running checks on each.
This approach is equivalent to running many `awk` instances concurrently.

Why not use `vex`? This would require a tree-sitter grammar for `yuescript`, for which no public one exists. Creating one manually is an option but would divert my attention away from this project and possibly run afowl of the two-week Minecraft window.
