### PR TITLE
Clean error log on early exits

### DIFF
--- a/freight.yue
+++ b/freight.yue
@@ -23,6 +23,9 @@ import 'freight.logger'
 import 'spec'
 
 global skip_minecraft_tests = false
+-- Some tests have unsuppressible error output in valid cases. This is a hack
+-- to avoid mental false-positives by users.
+global run_ugly_tests = false
 
 force_error_on_bad_exit = false
 
@@ -43,6 +46,7 @@ main = (raw_args) ->
 
 run = (args) ->
   if args.test?
+    run_ugly_tests = args.test.run_ugly_tests
     skip_minecraft_tests = args.test.no_minecraft
     run_tests args.test.filter
   else if args.start?

--- a/freight.yue
+++ b/freight.yue
@@ -1,6 +1,6 @@
 local *
 
-import 'compat' as :apply_compat, :test_compat
+import 'compat' as :apply_compat, :HOST, :test_compat
 apply_compat!
 
 import 'quicktype' as :declare_type
@@ -24,6 +24,8 @@ import 'spec'
 
 global skip_minecraft_tests = false
 
+force_error_on_bad_exit = false
+
 main = (raw_args) ->
   args, ok = Args::parse raw_args
   if not ok
@@ -31,6 +33,8 @@ main = (raw_args) ->
 
   logger.set_log_verbosity args.verbose
   spec.set_log_verbosity args.verbose
+
+  force_error_on_bad_exit = args.force_error_on_bad_exit
 
   if args.instrument
     instrument -> run args
@@ -73,5 +77,12 @@ catch err
   if err != 'EXIT(0)'
     print debug.traceback err
     ok = false
-if not ok
-  os.exit 1
+switch HOST
+  when 'native'
+    if not ok
+      os.exit 1
+  when 'minecraft'
+    if not ok and force_error_on_bad_exit
+      os.exit 1
+  else
+    error "internal error: unrecognised host #{HOST}"

--- a/freight.yue
+++ b/freight.yue
@@ -48,7 +48,9 @@ run = (args) ->
   if args.test?
     run_ugly_tests = args.test.run_ugly_tests
     skip_minecraft_tests = args.test.no_minecraft
-    run_tests args.test.filter
+    ok = run_tests args.test.filter
+    if not ok
+      os.exit 1
   else if args.start?
     if not args.ignore_monitor
       detect_and_use_monitor!

--- a/freight/args.yue
+++ b/freight/args.yue
@@ -24,6 +24,10 @@ export class Args
         \short nil
         \global!
         \hidden!
+      \add with Flag 'force-error-on-bad-exit'
+        \hidden!
+        \short nil
+        \global!
       \add with Subcommand 'test'
         \description 'test the program and exit'
         \add with Flag 'no-minecraft'

--- a/freight/args.yue
+++ b/freight/args.yue
@@ -33,6 +33,9 @@ export class Args
         \add with Flag 'no-minecraft'
           \description 'skip in-world tests'
           \short nil
+        \add with Flag 'run-ugly-tests'
+          \description 'tests with deliberate unsuppressible errors'
+          \short nil
         \add with Param 'filter'
           \description 'run only tests matching this pattern'
           \default nil

--- a/freight/upgrade/tester.yue
+++ b/freight/upgrade/tester.yue
@@ -20,7 +20,8 @@ export class Tester
       assert \close!
     local testing_ok
     if write_ok
-      testing_ok = execute tmp_path, 'test'
+      -- TODO(kcza): test this!
+      testing_ok = execute tmp_path, 'test', '--force-error-on-bad-exit'
     assert os.remove tmp_path
 
     if not write_ok

--- a/freight/upgrade/tester.yue
+++ b/freight/upgrade/tester.yue
@@ -20,7 +20,6 @@ export class Tester
       assert \close!
     local testing_ok
     if write_ok
-      -- TODO(kcza): test this!
       testing_ok = execute tmp_path, 'test', '--force-error-on-bad-exit'
     assert os.remove tmp_path
 

--- a/freight/upgrade/tester.yue
+++ b/freight/upgrade/tester.yue
@@ -48,36 +48,38 @@ spec ->
       $expect_that ok, eq true
       $expect_that err, eq nil
 
-    -- NOTE: the following two tests are deactivated as it is impossible to
-    -- both suppress the output of a subprocess and capture its return value
-    -- (even just as ok/!ok) in both Cobalt lua (used by CC:Tweaked) and luajit
-    -- (used for external testing). As such, these tests emit worrying error
-    -- output which will be very disconcerting for the user.
-    --
-    -- it 'rejects invalid releases', ->
-    --   release =
-    --     file: 'freight'
-    --     version: '12345'
-    --     content: [[
-    --       error('MARKER_ERROR')
-    --     ]]
-    --
-    --   ok, err = Tester!\test release
-    --   expect_that ok, eq false
-    --   expect_that err, has_type 'string'
-    --
-    -- it 'executes the test command', ->
-    --   release =
-    --     file: 'frieght'
-    --     version: '12345'
-    --     content: [[
-    --       for i = 1, select('#', ...) do
-    --         if select(i, ...) == 'test' then
-    --           return
-    --         end
-    --       end
-    --       error("must pass 'test' to freight")
-    --     ]]
-    --   ok, err = Tester!\test release
-    --   expect_that ok, eq true
-    --   expect_that err, eq nil
+    if _G.run_ugly_tests
+      -- NOTE: the following two tests are deactivated by default as it is
+      -- impossible to both suppress the output of a subprocess and capture its
+      -- return value (even just as ok/!ok) in both Cobalt lua (used by
+      -- CC:Tweaked) and luajit (used for external testing). As such, these
+      -- tests emit worrying error output when they pass, which will be very
+      -- disconcerting for the user.
+
+      it 'rejects invalid releases', ->
+        release =
+          file: 'freight'
+          version: '12345'
+          content: [[
+            error('MARKER_ERROR')
+          ]]
+
+        ok, err = Tester!\test release
+        $expect_that ok, eq false
+        $expect_that err, has_type 'string'
+
+      it 'executes the test command', ->
+        release =
+          file: 'frieght'
+          version: '12345'
+          content: [[
+            for i = 1, select('#', ...) do
+              if select(i, ...) == 'test' then
+                return
+              end
+            end
+            error("must pass 'test' to freight")
+          ]]
+        ok, err = Tester!\test release
+        $expect_that ok, eq true
+        $expect_that err, eq nil

--- a/scripts/release
+++ b/scripts/release
@@ -2,11 +2,23 @@
 
 set -e
 
+if [[ $# -ne 1 ]]; then
+	cat <<- EOF
+		expected usage: $0 <artifact>
+	EOF
+	exit 1
+fi
+
+if ! luajit $1 test --run-ugly-tests 2>/dev/null; then
+	echo 'some tests failed'
+	luajit $1 test --run-ugly-tests
+fi
+
 if [[ ! -d release/ ]]; then
 	mkdir release
 fi
 
-cp $@ release/
+cp $1 release/
 
 pushd release/
 

--- a/spec.yue
+++ b/spec.yue
@@ -678,5 +678,7 @@ export run_tests = (filter) ->
 
   log ->
     "#{Test.num_run} checks run"
-  if Test.num_failures > 0
+  ok = Test.num_failures == 0
+  if not ok
     print "#{Test.num_failures} checks failed!"
+  ok


### PR DESCRIPTION
This PR is required due to three deficiencies in CC:Tweaked's lua:

1. CC:Tweaked's lua does not support program exit codes. Program failures are reported through the presence of errors
2. Errors reported to the CC:Tweaked host cannot be silenced
3. CC:Tweaked's lua prohibits use of the `io.popen` function (which could be used to hide error output)

The result is that marker errors in child processes emitted during tests are always reported to the reader, even though they are expected to occur. This is extremely disconcerting for users when in reality, nothing is wrong. This is especially worrying when an error is printed before freight reports that a worldwide upgrade has completed!

This PR hence moves these 'ugly' tests behind a flag so that they may be run on request, but are absent when running tests normally, e.g. when upgrading freight versions.
