### PR TITLE
Avoid scheduling full station-sets

### DIFF
--- a/freight/nodes/factory/main.yue
+++ b/freight/nodes/factory/main.yue
@@ -227,7 +227,7 @@ class Factory
           [name] = do
             config = @get_station_config name
             known = config?
-            info = :name, :known, present_trains: {}
+            info = :name, :known, capacity: 0, present_trains: {}
             if known
               info = { ...config, ...info }
             info
@@ -235,6 +235,7 @@ class Factory
         present_train = station\train_name!
         if present_train?
           info.present_trains[] = present_train
+        info.capacity += 1
 
     with known: {}, unknown: {}
       for _, station_info in pairs detected_station_info
@@ -294,7 +295,7 @@ declare_type 'UnknownDetectedStation', [[
   + DetectedTrains
 ]]
 declare_type 'DetectedTrains', [[{
-  -- TODO(kcza): add max_trains: number,
+  capacity: number,
   present_trains: [string],
 }]]
 declare_type 'DetectedStockpile', [[{
@@ -524,10 +525,12 @@ spec ->
                   network: 'some-network'
                   type: 'inbound'
                   handles: 'minecraft:stone_bricks'
+                  capacity: 1
                   present_trains:
                     * 'train_1'
               unknown:
                 * name: 'unknown_station'
+                  capacity: 1
                   present_trains:
                     * 'train_2'
 

--- a/freight/nodes/marshal/main.yue
+++ b/freight/nodes/marshal/main.yue
@@ -354,11 +354,13 @@ spec ->
                       network: 'network_1'
                       type: 'outbound'
                       handles: 'dirt'
+                      capacity: 1
                       present_trains: {}
                     * name: "station_#{3*@count+1}"
                       network: 'network_2'
                       type: 'inbound'
                       handles: 'dirt'
+                      capacity: 1
                       present_trains: {}
                   :known, unknown: {}
                 when 'change-factory-stations'
@@ -367,11 +369,13 @@ spec ->
                       network: 'network_1'
                       type: 'outbound'
                       handles: 'dirt'
+                      capacity: 1
                       present_trains: {}
                     * name: "station_#{3*@count+2}"
                       network: 'network_3'
                       type: 'inbound'
                       handles: 'dirt'
+                      capacity: 1
                       present_trains: {}
                   :known, unknown: {}
                 else

--- a/freight/nodes/marshal/scheduler.yue
+++ b/freight/nodes/marshal/scheduler.yue
@@ -25,7 +25,7 @@ export class Scheduler
       if #inbound_station_addrs == 0
         log -> "no station at #{factory.name} accepts inbound #{resource}"
         return {}
-      inbound_station_addrs_by_network = @_station_addrs_by_network inbound_station_addrs
+      free_inbound_station_addrs_by_network = @_free_station_addrs_by_network inbound_station_addrs
 
       outbound_station_addrs = {}
       outbound_station_addrs_by_network = {}
@@ -52,13 +52,13 @@ export class Scheduler
         inbound_station_addrs,
         outbound_station_addrs_by_network
       @_yield_candidate_set yielded_local_candiates, @_outbound_local_schedule_candidates resource,
-          inbound_station_addrs_by_network,
+          free_inbound_station_addrs_by_network,
           outbound_station_addrs
 
       -- Yield candidates from anywhere in any network
       train_addrs = @_train_addrs factories
       @_yield_global_schedule_candidates resource,
-        inbound_station_addrs_by_network,
+        free_inbound_station_addrs_by_network,
         outbound_station_addrs_by_network,
         train_addrs
 
@@ -130,10 +130,6 @@ export class Scheduler
           if not outbound_station_addr?
             continue
 
-          outbound_station = outbound_station_addr.station
-          if #outbound_station.present_trains >= outbound_station.capacity
-            continue -- Avoid sending train to full station.
-
           [] =
             train_addr:
               name: train_name
@@ -147,20 +143,16 @@ export class Scheduler
     @rand\shuffle ret
     ret
 
-  _outbound_local_schedule_candidates: F '(string, {string->[StationAddress]}, [StationAddress]) => [ScheduleCandidate]', (resource, inbound_station_addrs_by_network, outbound_station_addrs) =>
+  _outbound_local_schedule_candidates: F '(string, {string->[StationAddress]}, [StationAddress]) => [ScheduleCandidate]', (resource, free_inbound_station_addrs_by_network, outbound_station_addrs) =>
     ret = with {}
       for outbound_station_addr in *outbound_station_addrs
         { :factory, :station } = outbound_station_addr
 
         for train_name in *outbound_station_addr.station.present_trains
-          inbound_station_addrs = inbound_station_addrs_by_network[outbound_station_addr.station.network]
+          inbound_station_addrs = free_inbound_station_addrs_by_network[outbound_station_addr.station.network]
           if not inbound_station_addrs? or #inbound_station_addrs == 0
             continue
           inbound_station_addr = @rand\pick inbound_station_addrs
-
-          inbound_station = inbound_station_addr.station
-          if #inbound_station.present_trains >= inbound_station.capacity
-            continue -- Avoid routing train to full station.
 
           [] =
             train_addr:
@@ -175,7 +167,7 @@ export class Scheduler
     @rand\shuffle ret
     ret
 
-  _yield_global_schedule_candidates: F '(string, {string->[StationAddress]}, {string->[StationAddress]}, [TrainAddress]) => <>', (resource, inbound_station_addrs_by_network, outbound_station_addrs_by_network, train_addrs) =>
+  _yield_global_schedule_candidates: F '(string, {string->[StationAddress]}, {string->[StationAddress]}, [TrainAddress]) => <>', (resource, free_inbound_station_addrs_by_network, outbound_station_addrs_by_network, train_addrs) =>
     attempts = 0
     while true
       attempts += 1
@@ -188,23 +180,15 @@ export class Scheduler
 
       network = train_addr.station.network
 
-      inbound_station_addrs = inbound_station_addrs_by_network[network]
+      inbound_station_addrs = free_inbound_station_addrs_by_network[network]
       if not inbound_station_addrs? or #inbound_station_addrs == 0
         continue
       inbound_station_addr = @rand\pick inbound_station_addrs
-
-      inbound_station = inbound_station_addr.station
-      if #inbound_station.present_trains >= inbound_station.capacity
-        continue -- Avoid sending train to full station.
 
       outbound_station_addrs = outbound_station_addrs_by_network[network]
       if not outbound_station_addrs? or #outbound_station_addrs == 0
         continue
       outbound_station_addr = @rand\pick outbound_station_addrs
-
-      outbound_station = outbound_station_addr.station
-      if #outbound_station.present_trains >= outbound_station.capacity
-        continue -- Avoid sending train to full station.
 
       @_yield_candidate
         :train_addr
@@ -214,10 +198,14 @@ export class Scheduler
           inbound_addr: inbound_station_addr
           outbound_addr: outbound_station_addr
 
-  _station_addrs_by_network: F '([StationAddress]) => {string->[StationAddress]}', (addrs) =>
+  _free_station_addrs_by_network: F '([StationAddress]) => {string->[StationAddress]}', (addrs) =>
     with {}
       for addr in *addrs
-        network = addr.station.network
+        station = addr.station
+        if #station.present_trains >= station.capacity
+          continue
+
+        network = station.network
         if not [network]?
           [network] = {addr}
         else
@@ -299,7 +287,7 @@ export class Scheduler
 
   ut_outbound_local_schedule_candidates: F '(string, Factory, [Factory]) => [ScheduleCandidate]', (resource, factory, factories) =>
     inbound_station_addrs = @_inbound_station_addrs resource, factory
-    inbound_station_addrs_by_network = @_station_addrs_by_network inbound_station_addrs
+    free_inbound_station_addrs_by_network = @_free_station_addrs_by_network inbound_station_addrs
 
     outbound_station_addrs = {}
     do
@@ -317,12 +305,12 @@ export class Scheduler
           outbound_station_addrs[] = addr
 
     @_outbound_local_schedule_candidates resource,
-      inbound_station_addrs_by_network,
+      free_inbound_station_addrs_by_network,
       outbound_station_addrs
 
   ut_yield_global_schedule_candidates: F '(string, Factory, [Factory]) => [ScheduleCandidate]', (resource, factory, factories) =>
     inbound_station_addrs = @_inbound_station_addrs resource, factory
-    inbound_station_addrs_by_network = @_station_addrs_by_network inbound_station_addrs
+    free_inbound_station_addrs_by_network = @_free_station_addrs_by_network inbound_station_addrs
 
     outbound_station_addrs_by_network = {}
     do
@@ -340,7 +328,7 @@ export class Scheduler
 
     train_addrs = @_train_addrs factories
     @_yield_global_schedule_candidates resource,
-      inbound_station_addrs_by_network,
+      free_inbound_station_addrs_by_network,
       outbound_station_addrs_by_network,
       train_addrs
 

--- a/freight/nodes/marshal/scheduler.yue
+++ b/freight/nodes/marshal/scheduler.yue
@@ -124,15 +124,20 @@ export class Scheduler
   _inbound_local_schedule_candidates: F '(string, Factory, [StationAddress], {string->[StationAddress]}) => [ScheduleCandidate]', (resource, factory, inbound_station_addrs, outbound_station_addrs_by_network) =>
     ret = with {}
       for inbound_station_addr in *inbound_station_addrs
-        for train_name in *inbound_station_addr.station.present_trains
-          outbound_station_addr = @rand\pick outbound_station_addrs_by_network[inbound_station_addr.station.network]
+        station = inbound_station_addr.station
+        for train_name in *station.present_trains
+          outbound_station_addr = @rand\pick outbound_station_addrs_by_network[station.network]
           if not outbound_station_addr?
             continue
+
+          outbound_station = outbound_station_addr.station
+          if #outbound_station.present_trains >= outbound_station.capacity
+            continue -- Avoid sending train to full station.
 
           [] =
             train_addr:
               name: train_name
-              station: inbound_station_addr.station
+              :station
               :factory
             :inbound_station_addr
             :outbound_station_addr
@@ -145,17 +150,23 @@ export class Scheduler
   _outbound_local_schedule_candidates: F '(string, {string->[StationAddress]}, [StationAddress]) => [ScheduleCandidate]', (resource, inbound_station_addrs_by_network, outbound_station_addrs) =>
     ret = with {}
       for outbound_station_addr in *outbound_station_addrs
+        { :factory, :station } = outbound_station_addr
+
         for train_name in *outbound_station_addr.station.present_trains
           inbound_station_addrs = inbound_station_addrs_by_network[outbound_station_addr.station.network]
           if not inbound_station_addrs? or #inbound_station_addrs == 0
             continue
           inbound_station_addr = @rand\pick inbound_station_addrs
 
+          inbound_station = inbound_station_addr.station
+          if #inbound_station.present_trains >= inbound_station.capacity
+            continue -- Avoid routing train to full station.
+
           [] =
             train_addr:
               name: train_name
-              station: outbound_station_addr.station
-              factory: outbound_station_addr.factory
+              :station
+              :factory
             :inbound_station_addr
             :outbound_station_addr
             schedule: @_train_schedule
@@ -182,10 +193,18 @@ export class Scheduler
         continue
       inbound_station_addr = @rand\pick inbound_station_addrs
 
+      inbound_station = inbound_station_addr.station
+      if #inbound_station.present_trains >= inbound_station.capacity
+        continue -- Avoid sending train to full station.
+
       outbound_station_addrs = outbound_station_addrs_by_network[network]
       if not outbound_station_addrs? or #outbound_station_addrs == 0
         continue
       outbound_station_addr = @rand\pick outbound_station_addrs
+
+      outbound_station = outbound_station_addr.station
+      if #outbound_station.present_trains >= outbound_station.capacity
+        continue -- Avoid sending train to full station.
 
       @_yield_candidate
         :train_addr
@@ -540,23 +559,32 @@ spec ->
 
       rand = make_pseudo_random!
 
+      spare_capacity = (station_addr) ->
+        station = station_addr.station
+        station.capacity - #station.present_trains
+
       inbound_local_candidates = do
         scheduler = Scheduler rand
         scheduler\ut_inbound_local_schedule_candidates resource, factory_with_shortage_of_resource, factories
       for inbound_local_candidate in *inbound_local_candidates
         $expect_that inbound_local_candidate.train_addr.name, matches '^valid_inbound_local_train_%d+$'
+        $expect_that (spare_capacity inbound_local_candidate.outbound_station_addr), gt 0
 
       outbound_local_candidates = do
         scheduler = Scheduler rand
         scheduler\ut_outbound_local_schedule_candidates resource, factory_with_shortage_of_resource, factories
       for outbound_local_candidate in *outbound_local_candidates
         $expect_that outbound_local_candidate.train_addr.name, matches '^valid_outbound_local_train_%d+$'
+        $expect_that (spare_capacity outbound_local_candidate.inbound_station_addr), gt 0
 
       global_candidates = do
         limit = SCHEDULE_LIMIT - #inbound_local_candidates - #outbound_local_candidates
         gather_candidates limit, coroutine.create ->
           scheduler = Scheduler rand
           scheduler\ut_yield_global_schedule_candidates resource, factory_with_shortage_of_resource, factories
+      for global_candidate in *global_candidates
+        $expect_that (spare_capacity global_candidate.outbound_station_addr), gt 0
+        $expect_that (spare_capacity global_candidate.inbound_station_addr), gt 0
 
       all_candidates = do
         gather_candidates SCHEDULE_LIMIT, do

--- a/freight/nodes/marshal/scheduler.yue
+++ b/freight/nodes/marshal/scheduler.yue
@@ -348,6 +348,7 @@ spec ->
             type: 'inbound'
             handles: resource
             network: network
+            capacity: 3
             present_trains:
               * 'valid_inbound_local_train_1'
               * 'valid_inbound_local_train_2'
@@ -355,6 +356,7 @@ spec ->
             type: 'inbound'
             handles: resource
             network: network
+            capacity: 2
             present_trains:
               * 'valid_inbound_local_train_3'
               * 'valid_inbound_local_train_4'
@@ -362,27 +364,32 @@ spec ->
             type: 'outbound'
             handles: resource
             network: network
+            capacity: 2
             present_trains:
               * 'wrong_type_train'
           * name: 'wrong_resource_station'
             type: 'inbound'
             handles: 'minecraft:diamond_axe'
             network: network
+            capacity: 2
             present_trains:
               * 'wrong_resource_train'
           * name: 'wrong_network_station'
             type: 'inbound'
             handles: resource
             network: 'wrong_shortage_network'
+            capacity: 2
             present_trains:
               * 'wrong_network_train'
           * name: 'no_trains_inbound_station'
             type: 'inbound'
             handles: resource
             network: network
+            capacity: 1
             present_trains: {}
         unknown:
           * name: 'unknown_station'
+            capacity: 2
             present_trains:
               * 'unknown_station_train'
       stockpile:
@@ -416,6 +423,7 @@ spec ->
             type: 'outbound'
             handles: resource
             network: network
+            capacity: 3
             present_trains:
               * 'valid_outbound_local_train_1'
               * 'valid_outbound_local_train_2'
@@ -423,27 +431,39 @@ spec ->
             type: 'inbound'
             handles: resource
             network: network
+            capacity: 2
             present_trains:
               * 'wrong_type_surplus_train'
           * name: 'wrong_resource_surplus_station'
             type: 'outbound'
             handles: 'minecraft:diamond_axe'
             network: network
+            capacity: 2
             present_trains:
               * 'wrong_resource_surplus_train'
           * name: 'wrong_network_surplus_station'
             type: 'outbound'
             handles: resource
             network: 'wrong_surplus_network'
+            capacity: 2
             present_trains:
               * 'wrong_network_surplus_train'
           * name: 'no_trains_surplus_station'
             type: 'inbound'
             handles: resource
             network: network
+            capacity: 1
             present_trains: {}
+          * name: 'full_surplus_station'
+            type: 'inbound'
+            handles: resource
+            network: network
+            capacity: 1
+            present_trains:
+              * 'full_surplus_train'
         unknown:
           * name: 'unknown_surplus_station'
+            capacity: 2
             present_trains:
               * 'unknown_station_surplus_train'
       stockpile:


### PR DESCRIPTION
This PR adds the capacity of a station to the `FactoryHeartbeat`, allowing the scheduler to avoid sending trains to full station-sets. (Where a 'station-set' is defined as a set of same-name stations)
