### PR TITLE
Add remote declarations

### DIFF
--- a/freight.yue
+++ b/freight.yue
@@ -14,6 +14,7 @@ import 'quicktype' as :F
 import 'spec' as :run_tests
 
 import 'freight.cmd.clean'
+import 'freight.cmd.declare'
 import 'freight.cmd.disable'
 import 'freight.cmd.enable'
 import 'freight.cmd.init'
@@ -63,6 +64,8 @@ run = (args) ->
     enable.main args.enable
   else if args.disable?
     disable.main args.disable
+  else if args.declare?
+    declare.main args.declare
   else if args.upgrade?
     upgrade.main args.upgrade
   else

--- a/freight/args.yue
+++ b/freight/args.yue
@@ -15,10 +15,11 @@ export class Args
       \add with Flag 'verbose'
         \description 'log verbosely'
         \global!
-      \add with Flag 'ignore-monitor'
-        \description 'log output on this computer'
-        \short nil
-        \global!
+      if not pocket?
+        \add with Flag 'ignore-monitor'
+          \description 'log output on this computer'
+          \short nil
+          \global!
       \add with Flag 'instrument'
         \description 'gather performance data when executing'
         \short nil
@@ -40,6 +41,7 @@ export class Args
           \description 'run only tests matching this pattern'
           \default nil
       \add (require 'freight.cmd.clean').subcommand
+      \add (require 'freight.cmd.declare').subcommand
       \add (require 'freight.cmd.disable').subcommand
       \add (require 'freight.cmd.enable').subcommand
       \add (require 'freight.cmd.init').subcommand

--- a/freight/cmd/declare.yue
+++ b/freight/cmd/declare.yue
@@ -1,0 +1,109 @@
+local *
+local DeclareTrainState
+local DeclareTrainStateResponse
+
+import 'clap' as :Flag, :Param, :Subcommand
+import 'freight.peripheral.uplink' as :IdempotenceToken, :Packet, :TIMEOUT, :Uplink
+import 'quicktype' as :declare_type, :F
+import 'spec' as :spec
+
+declare_type 'DeclareArgs', [[{
+  train: {
+    name: string,
+    state: TrainState,
+  },
+}]]
+declare_type 'TrainState', '"cleared"|"reserved"'
+export subcommand = with Subcommand 'declare'
+  \description 'make declarations about the state of the system'
+  \add with Subcommand 'train'
+    \description 'declare things about trains'
+    \add with Param 'name'
+      \description 'name of the train'
+    \add with Param 'state'
+      \description 'new state of the train'
+      \options
+        * 'cleared'
+        * 'reserved'
+
+export main = F '({}) -> <>', (args) ->
+  import 'spec' as :repr
+  print repr args
+
+  with Declarer Uplink!
+    err = if args.train?
+      { :name, :state } = args.train
+      \declare_train_state name, state
+    else
+      error 'internal error: nothing to declare'
+
+    if err?
+      print "cannot make declaration: #{err}"
+
+  -- TODO(kcza): complete me!
+  -- * broadcast a train-reset message
+  -- * await response
+  -- * print response if okay
+  error 'TODO'
+
+class Declarer
+  new: F '(Uplink) => <>', (@uplink) =>
+
+  declare_train_state: F '(string, TrainState) => ?string', (train_name, state) =>
+    idemp_tok = IdempotenceToken!
+    @uplink\broadcast DeclareTrainState idemp_tok, train_name, state
+
+    MAX_ATTEMPTS = 3
+    for i = 1, MAX_ATTEMPTS
+      if i > 1
+        print "awaiting response (attempt #{i}/#{MAX_ATTEMPTS})"
+
+      _, resp = @uplink\receive_from_any DeclareTrainStateResponse, timeout: 5
+      if resp == TIMEOUT
+        continue
+      if resp.idemp_tok != idemp_tok
+        continue
+      return resp.error_reason
+    return "no response from marshal after #{MAX_ATTEMPTS} attempts"
+
+export class DeclareTrainState extends Packet
+  new: F '(IdempotenceToken, string, TrainState) => <>', (@idemp_tok, @name, @state) =>
+
+export class DeclareTrainStateResponse extends Packet
+  new: F '(IdempotenceToken, ?string) => <>', (@idemp_tok, @error_reason) =>
+
+spec ->
+  import 'spec_macros' as $
+
+  import 'freight.peripheral.uplink' as :TestUplinkBackend
+  import 'spec' as :describe, :it, :matchers
+
+  import deep_eq, eq, has_fields, len, lt, matches from matchers
+
+  describe 'Declarer', ->
+    it 'sends declarations', ->
+      err = nil
+
+      PC_ID = 12345
+      sent = {}
+      broadcasted = {}
+      local idemp_tok
+      uplink = Uplink TestUplinkBackend
+        send: (pc_id, message, protocol) =>
+          idemp_tok = message.idemp_tok
+          sent[] = :pc_id, :message, :protocol
+        broadcast: (message, protocol) =>
+          idemp_tok = message.idemp_tok
+          broadcasted[] = :message, :protocol
+        receive: (_, _) =>
+          message = DeclareTrainStateResponse idemp_tok, err
+          PC_ID, message, message\protocol!
+
+      with Declarer uplink
+        TRAIN_NAME = 'test-train'
+        TRAIN_STATE = 'cleared'
+
+        $expect_that (\declare_train_state TRAIN_NAME, TRAIN_STATE), eq nil
+
+        err = 'some error message'
+        $expect_that (\declare_train_state TRAIN_NAME, TRAIN_STATE), eq err

--- a/freight/cmd/declare.yue
+++ b/freight/cmd/declare.yue
@@ -9,7 +9,7 @@ import 'quicktype' as :declare_type, :F
 import 'spec' as :spec
 
 declare_type 'DeclareArgs', [[{
-  train: {
+  train: ?{
     name: string,
     state: TrainState,
   },

--- a/freight/cmd/declare.yue
+++ b/freight/cmd/declare.yue
@@ -3,6 +3,7 @@ local DeclareTrainState
 local DeclareTrainStateResponse
 
 import 'clap' as :Flag, :Param, :Subcommand
+import 'freight.pc' as :Pc
 import 'freight.peripheral.uplink' as :IdempotenceToken, :Packet, :TIMEOUT, :Uplink
 import 'quicktype' as :declare_type, :F
 import 'spec' as :spec
@@ -27,10 +28,7 @@ export subcommand = with Subcommand 'declare'
         * 'reserved'
 
 export main = F '({}) -> <>', (args) ->
-  import 'spec' as :repr
-  print repr args
-
-  with Declarer Uplink!
+  with Declarer Uplink!, Pc!
     err = if args.train?
       { :name, :state } = args.train
       \declare_train_state name, state
@@ -40,18 +38,12 @@ export main = F '({}) -> <>', (args) ->
     if err?
       print "cannot make declaration: #{err}"
 
-  -- TODO(kcza): complete me!
-  -- * broadcast a train-reset message
-  -- * await response
-  -- * print response if okay
-  error 'TODO'
-
 class Declarer
-  new: F '(Uplink) => <>', (@uplink) =>
+  new: F '(Uplink, Pc) => <>', (@uplink, @pc) =>
 
   declare_train_state: F '(string, TrainState) => ?string', (train_name, state) =>
     idemp_tok = IdempotenceToken!
-    @uplink\broadcast DeclareTrainState idemp_tok, train_name, state
+    @uplink\broadcast DeclareTrainState idemp_tok, @pc\id!, train_name, state
 
     MAX_ATTEMPTS = 3
     for i = 1, MAX_ATTEMPTS
@@ -66,8 +58,14 @@ class Declarer
       return resp.error_reason
     return "no response from marshal after #{MAX_ATTEMPTS} attempts"
 
+declare_type 'DeclareTrainState', [[{
+  idemp_tok: IdempotenceToken,
+  pc_id: number,
+  name: string,
+  state: TrainState,
+}]]
 export class DeclareTrainState extends Packet
-  new: F '(IdempotenceToken, string, TrainState) => <>', (@idemp_tok, @name, @state) =>
+  new: F '(IdempotenceToken, number, string, TrainState) => <>', (@idemp_tok, @pc_id, @name, @state) =>
 
 export class DeclareTrainStateResponse extends Packet
   new: F '(IdempotenceToken, ?string) => <>', (@idemp_tok, @error_reason) =>
@@ -75,13 +73,14 @@ export class DeclareTrainStateResponse extends Packet
 spec ->
   import 'spec_macros' as $
 
+  import 'freight.pc' as :TestPcBackend
   import 'freight.peripheral.uplink' as :TestUplinkBackend
   import 'spec' as :describe, :it, :matchers
 
   import deep_eq, eq, has_fields, len, lt, matches from matchers
 
   describe 'Declarer', ->
-    it 'sends declarations', ->
+    it 'declares train states', ->
       err = nil
 
       PC_ID = 12345
@@ -98,8 +97,9 @@ spec ->
         receive: (_, _) =>
           message = DeclareTrainStateResponse idemp_tok, err
           PC_ID, message, message\protocol!
-
-      with Declarer uplink
+      pc = Pc TestPcBackend
+        id: => 1
+      with Declarer uplink, pc
         TRAIN_NAME = 'test-train'
         TRAIN_STATE = 'cleared'
 

--- a/freight/nodes/marshal/main.yue
+++ b/freight/nodes/marshal/main.yue
@@ -1,9 +1,9 @@
 local *
-local TrainResetResponse
 
 -- TODO(kcza): Check station-name uniqueness
 
 import 'compat' as :HOST
+import 'freight.cmd.declare' as :DeclareTrainStateResponse
 import 'freight.data.multiplexer' as :Multiplexer
 import 'freight.logger' as :log
 import 'freight.nodes.factory.main' as :FactoryHeartbeat, :ScheduleRequest, :ScheduleResponse
@@ -146,7 +146,7 @@ class Marshal
   read_network: F '() => <>', =>
     _, message = @uplink\receive_from_any!
     switch message\protocol!
-      when 'FactoryHeartbeat', 'TrainReset'
+      when 'FactoryHeartbeat', 'DeclareTrainState'
         @events\send type: 'network-message', :message
       else
         log -> "ignoring #{message\protocol!} message"
@@ -200,8 +200,8 @@ class Marshal
     switch message\protocol!
       when 'FactoryHeartbeat'
         @on_factory_heartbeat message
-      when 'TrainReset'
-        @on_train_reset message
+      when 'DeclareTrainState'
+        @on_declare_train_state message
       else
         error "internal error: unexpected network message protocol reached marshal core '#{message\protocol!}'"
 
@@ -308,10 +308,17 @@ class Marshal
 
     print "no trains available to take #{resource} to #{factory.name}, will re-attempt next heartbeat"
 
-  on_train_reset: F '(TrainReset) => <>', (message) =>
-    { :idemp_tok, :train_name, :pc_id } = message
-    err = @promise_tracker\declare_train_found train_name
-    @uplink\send_to pc_id, TrainResetResponse idemp_tok, err
+  on_declare_train_state: F '(DeclareTrainState) => <>', (message) =>
+    { :idemp_tok, :pc_id, :name, :state } = message
+    err = switch state
+      when 'cleared' -- TODO(kcza): this name is a leak from the CLI
+        @promise_tracker\declare_train_found name
+      when 'reserved'
+        @promise_tracker\reserve name
+        nil
+      else
+        "internal error: unknown train state '#{state}'"
+    @uplink\send_to pc_id, DeclareTrainStateResponse idemp_tok, err
 
   ut_stop_counting_epochs: F '() => <>', =>
     @do_count_epochs = false
@@ -335,20 +342,13 @@ class Marshal
   ut_train_is_lost: F '(string) => boolean', (train_name) =>
     @promise_tracker\train_is_lost train_name
 
-declare_type 'TrainReset', [[{
-  idemp_tok: IdempotenceToken,
-  pc_id: number,
-  train_name: string,
-}]]
-export class TrainReset extends Packet
-  new: F '(IdempotenceToken, number, string) => <>', (@idemp_tok, @pc_id, @train_name) =>
-
-export class TrainResetResponse extends Packet
-  new: F '(IdempotenceToken, ?string) => <>', (@idemp_tok, @error_reason) =>
+  ut_train_is_reserved: F '(string) => boolean', (train_name) =>
+    @promise_tracker\train_is_promised train_name
 
 spec ->
   import 'spec_macros' as $
 
+  import 'freight.cmd.declare' as :DeclareTrainState
   import 'freight.nodes.marshal.clock' as :TestClock
   import 'spec' as :describe, :it, :matchers
 
@@ -527,7 +527,7 @@ spec ->
       --  - Ensure correct in/outbound handling
       --  - MAYBE Run many times, shim `pick` to ensure progression
 
-    describe '\\on_train_reset', ->
+    describe '\\on_declare_train_state', ->
       it 'handles lost and not lost trains', ->
         idemp_tok = IdempotenceToken!
 
@@ -544,7 +544,7 @@ spec ->
             @count += 1
             message = switch @count
               when 1, 2
-                TrainReset idemp_tok, PC_ID, TRAIN_NAME
+                DeclareTrainState idemp_tok, PC_ID, TRAIN_NAME, 'cleared'
               else
                 nil
             if message?
@@ -570,7 +570,7 @@ spec ->
             message: has_fields
               idemp_tok: eq idemp_tok
               error_reason: eq nil
-            protocol: eq TrainResetResponse\protocol!
+            protocol: eq DeclareTrainStateResponse\protocol!
 
           \ut_step!
           $assert_that (\ut_train_is_lost TRAIN_NAME), eq false
@@ -580,4 +580,57 @@ spec ->
             message: has_fields
               idemp_tok: eq idemp_tok
               error_reason: matches 'was not lost'
-            protocol: eq TrainResetResponse\protocol!
+            protocol: eq DeclareTrainStateResponse\protocol!
+
+      it 'handles train reservations', ->
+        idemp_tok = IdempotenceToken!
+
+        sent = {}
+        PC_ID = 1
+        TRAIN_NAME = 'some-train-name'
+
+        config =
+          marshal:
+            network: 'mainline'
+        uplink = Uplink TestUplinkBackend
+          receive: (_, _) =>
+            @count ??= 0
+            @count += 1
+            message = switch @count
+              when 1, 2
+                DeclareTrainState idemp_tok, PC_ID, TRAIN_NAME, 'reserved'
+              else
+                nil
+            if message?
+              PC_ID, message, message\protocol!
+            else
+              nil, nil, nil
+          send: (pc_id, message, protocol) =>
+            sent[] = :pc_id, :message, :protocol
+            true
+
+        upgrade_listener = UpgradeListener config, uplink
+
+        with Marshal config, uplink, upgrade_listener, TestClock!
+          \ut_stop_counting_epochs!
+          $assert_that (\ut_train_is_reserved TRAIN_NAME), eq false
+
+          \ut_step!
+          $assert_that (\ut_train_is_reserved TRAIN_NAME), eq true
+          $assert_that sent, len eq 1
+          $expect_that sent[1], has_fields
+            pc_id: eq PC_ID
+            message: has_fields
+              idemp_tok: eq idemp_tok
+              error_reason: eq nil
+            protocol: eq DeclareTrainStateResponse\protocol!
+
+          \ut_step!
+          -- Check re-declarations are ignored
+          $assert_that sent, len eq 2
+          $expect_that sent[2], has_fields
+            pc_id: eq PC_ID
+            message: has_fields
+              idemp_tok: eq idemp_tok
+              error_reason: eq nil
+            protocol: eq DeclareTrainStateResponse\protocol!

--- a/freight/nodes/marshal/promise_tracker.yue
+++ b/freight/nodes/marshal/promise_tracker.yue
@@ -1,7 +1,5 @@
 local *
 
--- TODO(kcza): if train is lost, cancel its schedule (assuming it has the expected schedule!)
-
 import 'freight.nodes.marshal.clock' as :MinecraftClock
 import 'quicktype' as :declare_type, :F, :T
 import 'spec' as :spec
@@ -16,7 +14,7 @@ declare_type 'PromiseTracker', [[{
 declare_type 'Promise', [[{
   id: number,
   train: string,
-  stations: [PromiseStation],
+  stations: ?[PromiseStation],
   should_approach_index: number,
   deadline: ?number,
   max_step_duration: number
@@ -37,6 +35,15 @@ export class PromiseTracker
     @train_lost_promises = T '{string->Promise}', {}
 
   promise: F '(string, [PromiseStation], ?number, ?number) => Promise', (train, stations, max_step_duration=30*60, max_unload_duration=60) =>
+    @_promise train, stations, max_step_duration, max_unload_duration
+
+  reserve: F '(string) => <>', (train) =>
+    if promise = @promises[train] ?? @train_lost_promises[train]
+      @break_promise promise
+    @_promise train
+    return
+
+  _promise: F '(string, ?[PromiseStation], ?number, ?number) => Promise', (train, stations, max_step_duration=30*60, max_unload_duration=60) =>
     if @train_promises[train]?
       error "internal error: cannot promise already-promised train '#{train}'"
 
@@ -52,16 +59,17 @@ export class PromiseTracker
       :max_unload_duration
     @promises[id] = promise
     @train_promises[promise.train] = promise
-    for station in *stations
-      promise_set = @station_promise_sets[station.name] ?? do
-        promise_set =
-          count: 0
-          promises: {}
-        @station_promise_sets[station.name] = promise_set
-        promise_set
-      with promise_set
-        .count += 1
-        .promises[id] = promise
+    if stations?
+      for station in *stations
+        promise_set = @station_promise_sets[station.name] ?? do
+          promise_set =
+            count: 0
+            promises: {}
+          @station_promise_sets[station.name] = promise_set
+          promise_set
+        with promise_set
+          .count += 1
+          .promises[id] = promise
     promise
 
   _generate_id: F '() => number', =>
@@ -76,6 +84,8 @@ export class PromiseTracker
     @promises[id] = nil
     @train_lost_promises[promise.train] = nil
     @train_promises[promise.train] = nil
+    if not promise.stations?
+      return
     for station in *promise.stations
       with? @station_promise_sets[station.name]
         if .promises[id]?
@@ -118,6 +128,8 @@ export class PromiseTracker
     if @train_lost_promises[train_name]?
       return
 
+    if not promise.stations?
+      return
     with promise
       switch station_name
         when .stations[.should_approach_index].name
@@ -161,7 +173,7 @@ export class PromiseTracker
     for id in *ids_to_prune
       promise = @promises[id]
 
-      schedule_complete = promise.should_approach_index > #promise.stations
+      schedule_complete = promise.stations? and promise.should_approach_index > #promise.stations
       deadline_expired = promise.deadline? and now >= promise.deadline
       if schedule_complete and deadline_expired
         @promises[id] = nil
@@ -171,6 +183,8 @@ export class PromiseTracker
       else
         continue -- Already pruned
 
+      if not promise.stations?
+        continue
       for station in *promise.stations
         promise_set = @station_promise_sets[station.name]
         if promise_set.promises[id]?
@@ -369,3 +383,26 @@ spec ->
         $assert_that (\train_is_lost TRAIN_NAME), eq true
         $expect_that (\declare_train_found TRAIN_NAME), eq nil
         $expect_that (\train_is_lost TRAIN_NAME), eq false
+
+    it 'handles train reservation requests', ->
+      rand = PseudoRandom 12345
+      clock = TestClock!
+      with PromiseTracker rand, clock
+        TRAIN_NAME = 'test-train-name'
+
+        STATIONS =
+          * name: 'station-1'
+            capacity: 1
+        MAX_STEP_DURATION = 100
+        MAX_UNLOAD_DURATION = 10
+        \promise TRAIN_NAME, STATIONS, MAX_STEP_DURATION, MAX_UNLOAD_DURATION
+
+        clock.time += 2 * MAX_STEP_DURATION
+        $assert_that (\train_is_lost TRAIN_NAME), eq true
+
+        \reserve TRAIN_NAME
+        $expect_that (\train_is_promised 'test-train-name'), eq true
+        $assert_that (\train_is_lost TRAIN_NAME), eq false
+
+        clock.time += 2000000 -- No expiry
+        $expect_that (\train_is_promised 'test-train-name'), eq true

--- a/freight/nodes/marshal/promise_tracker.yue
+++ b/freight/nodes/marshal/promise_tracker.yue
@@ -38,7 +38,7 @@ export class PromiseTracker
     @_promise train, stations, max_step_duration, max_unload_duration
 
   reserve: F '(string) => <>', (train) =>
-    if promise = @promises[train] ?? @train_lost_promises[train]
+    if promise = @train_promises[train] ?? @train_lost_promises[train]
       @break_promise promise
     @_promise train
     return

--- a/freight/nodes/marshal/promise_tracker.yue
+++ b/freight/nodes/marshal/promise_tracker.yue
@@ -404,5 +404,5 @@ spec ->
         $expect_that (\train_is_promised 'test-train-name'), eq true
         $assert_that (\train_is_lost TRAIN_NAME), eq false
 
-        clock.time += 2000000 -- No expiry
+        clock.time += 2000000 -- Test no expiry
         $expect_that (\train_is_promised 'test-train-name'), eq true


### PR DESCRIPTION
  This PR adds a new CLI command and RPC to allow declarations to be made about trains. In particular, this allows trains to be declared as 'safe' for use after being lost and allows trains to be reserved (i.e. prevents their being scheduled by freight, intended for personal vehicles)
