### PR TITLE
Improve state data and end condition invariants

### DIFF
--- a/freight/state.yue
+++ b/freight/state.yue
@@ -28,8 +28,8 @@ export class StateMachineBuilder
       error "cannot build state machine: initial state '#{@_initial_state_name}' undefined"
     if @_states[@_initial_state_name]._data_type != 'nil'
       error 'cannot build state machine: initial state has data present'
-
-    -- TODO(kcza): validate!
+    if err = @validate_transitions!
+      error "cannot build state machine: #{err}"
 
     index = with {}
       .state = make_state @_initial_state_name, 'nil', nil
@@ -85,6 +85,41 @@ export class StateMachineBuilder
       <newindex>: (key, v) =>
         error "cannot add field '#{key}' to state machine"
     }
+
+  validate_transitions: F '() => ?string', =>
+    seen = T '{string}', {}
+    stack = T '[string]', {}
+    print '---'
+    local dfs
+    dfs = F '(string, {string->[string]}) -> <>', (state_name, transitions) ->
+      if seen[state_name]
+        return
+      seen[state_name] = true
+
+      for name in *stack
+        if name == state_name
+          return -- Already explored
+      stack[] = name
+      for neighbour in *assert transitions[state_name], "internal error: no transitions for #{state_name}"
+        dfs neighbour, transitions
+      stack[#stack] = nil
+
+      print "exploring #{state_name}"
+
+    dfs @_initial_state_name, with {}
+      for name, state in pairs @_states
+        [name] = [ state_name for state_name, _ in pairs state._transitions ]
+
+    non_reachable_from_start = with {}
+      for state_name, _ in pairs @_states
+        if not seen[state_name]
+          [] = state_name
+    table.sort non_reachable_from_start
+
+    if #non_reachable_from_start > 0
+      return "the following states are not reachable from the start state: #{table.concat non_reachable_from_start, ', '}"
+
+    return nil
 
 make_state = F '(string, string, any) -> {}', (name, data_type, data) ->
   T data_type, data
@@ -191,6 +226,25 @@ spec ->
         * 'state%-2 *%-> *state%-1'
       for str in *must_contain
         $expect_that graphviz_repr, matches str
+
+    it 'rejects invalid transition graphs', ->
+      builder = StateMachineBuilder!
+        \set_initial_state 'state-1'
+        \add_state with StateSpec 'state-1'
+          \add_transition_to 'state-2'
+        \add_state with StateSpec 'state-2'
+          \add_transition_to 'state-3'
+        \add_state with StateSpec 'state-3'
+          \add_transition_to 'state-1'
+      $expect_that builder\build, no_errors!
+
+      builder = StateMachineBuilder!
+        \set_initial_state 'state-1'
+        \add_state StateSpec 'state-1'
+        \add_state with StateSpec 'unreachable-1'
+          \add_transition_to 'unreachable-2'
+        \add_state StateSpec 'unreachable-2'
+      $expect_that builder\build, errors matches 'the following states are not reachable from the start state: unreachable%-1, unreachable%-2'
 
   describe 'valid_state_name', ->
     valid_idents =

--- a/freight/state.yue
+++ b/freight/state.yue
@@ -28,6 +28,8 @@ export class StateMachineBuilder
       error "cannot build state machine: initial state '#{@_initial_state_name}' undefined"
     if @_states[@_initial_state_name]._data_type != 'nil'
       error 'cannot build state machine: initial state has data present'
+    if err = @validate_end_states!
+      error "cannot build state machine: #{err}"
     if err = @validate_transitions!
       error "cannot build state machine: #{err}"
 
@@ -46,6 +48,11 @@ export class StateMachineBuilder
         .state = make_state name, new_state_spec._data_type, data
         if reporter?
           reporter .state
+
+      end_states = { state._name, true for _, state in pairs @_states when state._is_end }
+      .end = F '() => <>', =>
+        if not end_states[@state.name]
+          error "internal error: state #{@state.name} is not a valid end state"
 
       initial_state_name = @_initial_state_name
       .to_graphviz = F '() => string', =>
@@ -86,6 +93,12 @@ export class StateMachineBuilder
         error "cannot add field '#{key}' to state machine"
     }
 
+  validate_end_states: F '() => ?string', =>
+    for _, state in pairs @_states
+      if state._is_end
+        return nil
+    return "no end states declared"
+
   validate_transitions: F '() => ?string', =>
     seen = T '{string}', {}
     stack = T '[string]', {}
@@ -114,10 +127,29 @@ export class StateMachineBuilder
       for state_name, _ in pairs @_states
         if not seen[state_name]
           [] = state_name
-    table.sort non_reachable_from_start
-
     if #non_reachable_from_start > 0
+      table.sort non_reachable_from_start
       return "the following states are not reachable from the start state: #{table.concat non_reachable_from_start, ', '}"
+
+    seen = {}
+    stack = {}
+    back_transitions = with {}
+      for _, state in pairs @_states
+        [state._name] = {}
+      for _, state in pairs @_states
+        for neighbour, _ in pairs state._transitions
+          [neighbour][] = state._name
+    end_states = [ state._name for _, state in pairs @_states when state._is_end ]
+    for end_state in *end_states
+      dfs end_state, back_transitions
+
+    non_reachable_from_end = with {}
+      for state_name, _ in pairs @_states
+        if not seen[state_name]
+          [] = state_name
+    if #non_reachable_from_end > 0
+      table.sort non_reachable_from_end
+      return "the following states are not reachable from any end state: #{table.concat non_reachable_from_end, ', '}"
 
     return nil
 
@@ -137,6 +169,7 @@ make_state = F '(string, string, any) -> {}', (name, data_type, data) ->
       error "cannot directly assign state fields"
 
 declare_type 'StateSpec', [[{
+  _is_end: boolean,
   _transitions: {string},
   _data_type: ?string,
 }]]
@@ -148,6 +181,7 @@ export class StateSpec
     @_transitions = T '{string}', {}
     @_data_type = T 'string', 'nil'
     @_data_type_set = T 'boolean', false
+    @_is_end = T 'boolean', false
 
   add_transition_to: F '(string) => <>', (name) =>
     if not valid_state_name name
@@ -155,6 +189,9 @@ export class StateSpec
     if @_transitions[name]?
       error "cannot build state machine: transition #{@_name}->#{name} redefined"
     @_transitions[name] = true
+
+  declare_end_state: F '() => <>', =>
+    @_is_end = true
 
   set_data_type: F '(string) => <>', (data_type) =>
     if @_data_type_set
@@ -209,6 +246,7 @@ spec ->
       graphviz_repr = StateMachineBuilder!
         \set_initial_state 'state-1'
         \add_state with StateSpec 'state-1'
+          \declare_end_state!
           \add_transition_to 'state-2'
         \add_state with StateSpec 'state-2'
           \add_transition_to 'state-1'
@@ -230,7 +268,13 @@ spec ->
     it 'rejects invalid transition graphs', ->
       builder = StateMachineBuilder!
         \set_initial_state 'state-1'
+        \add_state StateSpec 'state-1'
+      $expect_that builder\build, errors matches 'no end states declared'
+
+      builder = StateMachineBuilder!
+        \set_initial_state 'state-1'
         \add_state with StateSpec 'state-1'
+          \declare_end_state!
           \add_transition_to 'state-2'
         \add_state with StateSpec 'state-2'
           \add_transition_to 'state-3'
@@ -240,11 +284,24 @@ spec ->
 
       builder = StateMachineBuilder!
         \set_initial_state 'state-1'
-        \add_state StateSpec 'state-1'
+        \add_state with StateSpec 'state-1'
+          \declare_end_state!
         \add_state with StateSpec 'unreachable-1'
           \add_transition_to 'unreachable-2'
         \add_state StateSpec 'unreachable-2'
       $expect_that builder\build, errors matches 'the following states are not reachable from the start state: unreachable%-1, unreachable%-2'
+
+      builder = StateMachineBuilder!
+        \set_initial_state 'state-1'
+        \add_state with StateSpec 'state-1'
+          \add_transition_to 'state-2'
+        \add_state with StateSpec 'state-2'
+          \declare_end_state!
+          \add_transition_to 'interminable-1'
+        \add_state with StateSpec 'interminable-1'
+          \add_transition_to 'interminable-2'
+        \add_state StateSpec 'interminable-2'
+      $expect_that builder\build, errors matches 'the following states are not reachable from any end state: interminable%-1, interminable%-2'
 
   describe 'valid_state_name', ->
     valid_idents =
@@ -269,9 +326,11 @@ spec ->
       StateMachineBuilder!
         \set_initial_state 'state-1'
         \add_state with StateSpec 'state-1'
+          \declare_end_state!
           \add_transition_to 'state-2'
           \add_transition_to 'state-3'
         \add_state with StateSpec 'state-2'
+          \declare_end_state!
           \set_data_type [[{
             hello: string,
             world: number,
@@ -279,6 +338,7 @@ spec ->
           }]]
           \add_transition_to 'state-1'
         \add_state with StateSpec 'state-3'
+          \declare_end_state!
           \set_data_type 'number'
         \build!
 
@@ -353,40 +413,58 @@ spec ->
         test_sm = make_test_sm!
         $expect_that (-> test_sm\goto 'state-3', spare: 'spare'), errors matches 'incorrect type'
 
-  describe 'set_reporter', ->
-    it 'is respected by state machines', ->
-      states = {}
-      test_sm = StateMachineBuilder!
-        \set_initial_state 'state-1'
-        \set_reporter (state) ->
-          states[] = state
-        \add_state with StateSpec 'state-1'
-          \add_transition_to 'state-2'
-        \add_state with StateSpec 'state-2'
-          \add_transition_to 'state-1'
-          \set_data_type [[{
-            hello: string,
-            world: number
-          }]]
-        \build!
+    describe '\\end', ->
+      it 'accepts valid end state', ->
+        state_machine = StateMachineBuilder!
+          \set_initial_state 'state-1'
+          \add_state with StateSpec 'state-1'
+            \declare_end_state!
 
-      data =
-        hello: 'asdf'
-        world: 123
+      it 'rejects invalid end state', ->
+        state_machine = StateMachineBuilder!
+          \set_initial_state 'state-1'
+          \add_state with StateSpec 'state-1'
+            \add_transition_to 'state-2'
+          \add_state with StateSpec 'state-2'
+            \declare_end_state!
+          \build!
+        $expect_that state_machine\end, errors matches 'state state%-1 is not a valid end state'
 
-      test_sm\goto 'state-2', data
+    describe 'set_reporter', ->
+      it 'is respected by state machines', ->
+        states = {}
+        test_sm = StateMachineBuilder!
+          \set_initial_state 'state-1'
+          \set_reporter (state) ->
+            states[] = state
+          \add_state with StateSpec 'state-1'
+            \add_transition_to 'state-2'
+          \add_state with StateSpec 'state-2'
+            \declare_end_state!
+            \add_transition_to 'state-1'
+            \set_data_type [[{
+              hello: string,
+              world: number
+            }]]
+          \build!
 
-      $expect_that states, deep_eq
-        * { name: 'state-2', ...data }
+        data =
+          hello: 'asdf'
+          world: 123
 
-      test_sm\goto 'state-1'
-      test_sm\goto 'state-2', data
-      test_sm\goto 'state-1'
-      test_sm\goto 'state-2', data
+        test_sm\goto 'state-2', data
 
-      $expect_that [ state for state in *states ], deep_eq
-        * { name: 'state-2', ...data }
-        * { name: 'state-1' }
-        * { name: 'state-2', ...data }
-        * { name: 'state-1' }
-        * { name: 'state-2', ...data }
+        $expect_that states, deep_eq
+          * { name: 'state-2', ...data }
+
+        test_sm\goto 'state-1'
+        test_sm\goto 'state-2', data
+        test_sm\goto 'state-1'
+        test_sm\goto 'state-2', data
+
+        $expect_that [ state for state in *states ], deep_eq
+          * { name: 'state-2', ...data }
+          * { name: 'state-1' }
+          * { name: 'state-2', ...data }
+          * { name: 'state-1' }
+          * { name: 'state-2', ...data }

--- a/freight/state.yue
+++ b/freight/state.yue
@@ -26,43 +26,24 @@ export class StateMachineBuilder
       error 'cannot build state machine: initial state undefined'
     if not @_states[@_initial_state_name]?
       error "cannot build state machine: initial state '#{@_initial_state_name}' undefined"
-    if not is_empty @_states[@_initial_state_name]._fields
-      error 'cannot build state machine: initial state has parameter fields'
+    if @_states[@_initial_state_name]._data_type != 'nil'
+      error 'cannot build state machine: initial state has data present'
+
+    -- TODO(kcza): validate!
 
     index = with {}
-      make_state = F '(string, {string->string}, {string->any}) -> {}', (name, arg_specs, args) ->
-        args = { ...args } -- Clone for safety
-
-        new_state = with :name, <>: {}
-          for field, spec in pairs arg_specs
-            [field] = T spec, args[field]
-            args[field] = nil
-          if field = next args
-            error "no such field #{name}.#{field}"
-          .<index> = (key) =>
-            if arg_specs[key]?
-              return nil -- Valid nil.
-            error "no such field #{name}.#{key}"
-        {
-          <index>: new_state
-          <newindex>: F '(string, any) => ?any', (key, value) =>
-            arg_spec = arg_specs[key]
-            if not arg_spec?
-              error "no such field #{name}.#{key}"
-            new_state[key] = T arg_spec, value
-        }
-      .state = make_state @_initial_state_name, {}, {}
+      .state = make_state @_initial_state_name, 'nil', nil
 
       states = @_states
 
       reporter = @_reporter
-      .goto = F '(string, ?{string -> any}) => <>', (name, args={}) =>
+      .goto = F '(string, any) => <>', (name, data) =>
         if not states[@state.name]?._transitions[name]
           error "no such transition: #{@state.name} -> #{name}"
         new_state_spec = states[name]
         if not new_state_spec?
           error "internal error: no such state '#{name}'"
-        .state = make_state name, new_state_spec._fields, args
+        .state = make_state name, new_state_spec._data_type, data
         if reporter?
           reporter .state
 
@@ -86,18 +67,18 @@ export class StateMachineBuilder
           [] = "  #{initial_state_name}[shape=point]"
           for state_name, state in pairs states
             [] = ''
-            field_names = [ field_name for field_name in pairs state._fields ]
-            table.sort field_names
-            if #field_names == 0
+
+            if not state._data_type?
               [] = "  #{state_name}"
             else
-              [] = "  #{state_name} [label=\"#{state_name}(#{table.concat field_names, ', '})\"]"
+              data_type_repr = state._data_type\gsub '\n *', ' '
+              [] = "  #{state_name}[label=\"#{state_name}(#{data_type_repr})\"]"
+
             for other_state in pairs state._transitions
               [] = "  #{state_name} -> #{other_state}"
 
           [] = '}'
         table.concat lines, '\n'
-
 
     T 'StateMachine', {
       <index>: index,
@@ -105,12 +86,24 @@ export class StateMachineBuilder
         error "cannot add field '#{key}' to state machine"
     }
 
-is_empty = (table) ->
-  not (next table)?
+make_state = F '(string, string, any) -> {}', (name, data_type, data) ->
+  T data_type, data
+  with :name, <>: {}
+    if 'table' == type data
+      .<index> = data
+    else
+      .<index> = value: data
+    .<newindex> = (key) =>
+      local key_repr
+      if 'string' == type key
+        key_repr = ".#{key}"
+      else
+        key_repr = "[#{key}]"
+      error "cannot directly assign state fields"
 
 declare_type 'StateSpec', [[{
   _transitions: {string},
-  _fields: {string -> string},
+  _data_type: ?string,
 }]]
 export class StateSpec
   new: F '(string) => <>', (@_name) =>
@@ -118,21 +111,21 @@ export class StateSpec
       error "cannot build state machine: state name '#{@_name}' not a valid identifier"
 
     @_transitions = T '{string}', {}
-    @_fields = T '{string -> string}', {}
+    @_data_type = T 'string', 'nil'
+    @_data_type_set = T 'boolean', false
 
   add_transition_to: F '(string) => <>', (name) =>
     if not valid_state_name name
       error "cannot build state machine: state name '#{name}' not a valid identifier"
-    if @_transitions[name]? or @_fields[name]?
+    if @_transitions[name]?
       error "cannot build state machine: transition #{@_name}->#{name} redefined"
     @_transitions[name] = true
 
-  add_field: F '(string, string) => <>', (name, type_spec) =>
-    if not valid_field_name name
-      error "cannot build state machine: field name '#{name}' not a valid identifier"
-    if @_fields[name] or @_transitions[name]?
-      error "cannot build state machine: field #{@_name}.#{name} redefined"
-    @_fields[name] = type_spec
+  set_data_type: F '(string) => <>', (data_type) =>
+    if @_data_type_set
+      error "cannot build state machine: data type for state #{@_name} already set"
+    @_data_type_set = true
+    @_data_type = data_type
 
 declare_type 'StateMachine', [[{
   state: {name: string},
@@ -141,9 +134,6 @@ declare_type 'StateMachine', [[{
 
 valid_state_name = F '(string) -> boolean', (name) ->
   (name\match '^[a-z][a-z0-9-]+[a-z0-9]$')?
-
-valid_field_name = F '(string) -> boolean', (name) ->
-  (name\match '^[a-z_][a-z0-9_]*$')?
 
 spec ->
   import 'spec_macros' as $
@@ -166,19 +156,18 @@ spec ->
         \add_state StateSpec 'waiting'
         \build!), errors matches "cannot build state machine: state 'waiting' redefined"
 
-    it 'rejects duplicate fields', ->
+    it 'rejects repeated \\set_data_type calls', ->
       $expect_that (-> StateMachineBuilder!
         \set_initial_state 'waiting'
         \add_state with StateSpec 'waiting'
-          \add_field 'hello', 'string'
-          \add_field 'hello', 'number'
-        \build!), errors matches "cannot build state machine: field waiting.hello redefined"
+          \set_data_type 'string'
+          \set_data_type 'number'
+        \build!), errors matches "cannot build state machine: data type for state waiting already set"
 
     it 'rejects invalid state names', ->
       $expect_that (-> StateMachineBuilder!
         \set_initial_state '-invalid'
-        \add_state with StateSpec '-invalid'
-          \add_field '-invalid', 'string'
+        \add_state StateSpec '-invalid'
         \build!), errors matches "cannot build state machine: state name '%-invalid' not a valid identifier"
 
     it 'formats itself as graphviz', ->
@@ -188,15 +177,17 @@ spec ->
           \add_transition_to 'state-2'
         \add_state with StateSpec 'state-2'
           \add_transition_to 'state-1'
-          \add_field 'hello', 'string'
-          \add_field 'world', 'number'
+          \set_data_type [[{
+            hello: string,
+            world: number,
+          }]]
         \build!
         \to_graphviz!
       must_contain =
         * 'digraph {'
         * 'state%-1 *%[shape=point%]'
         * 'state%-1 *%-> *state%-2'
-        * 'state%-2 *%[label="state%-2%(hello, world%)"%]'
+        * 'state%-2 *%[label="state%-2%({ hello: string, world: number,? }%)"%]'
         * 'state%-2 *%-> *state%-1'
       for str in *must_contain
         $expect_that graphviz_repr, matches str
@@ -219,28 +210,6 @@ spec ->
       it "rejects '#{invalid_ident}'", ->
         $expect_that (valid_state_name invalid_ident), eq false
 
-  describe 'valid_field_name', ->
-    valid_idents =
-      * 'hello'
-      * '_world123'
-    for valid_ident in *valid_idents
-      it "accepts #{valid_ident}", ->
-        $expect_that (valid_field_name valid_ident), eq true
-
-    invalid_idents =
-      * ''
-      * '1234'
-      * '-qwer'
-      * '.asdf'
-    for invalid_ident in *invalid_idents
-      it 'rejects invalid names', ->
-        $expect_that (valid_field_name invalid_ident), eq false
-
-  describe 'is_empty', ->
-    it 'returns correctly', ->
-      $expect_that (is_empty {}), eq true
-      $expect_that (is_empty {hello: 123}), eq false
-
   describe 'StateMachine', ->
     make_test_sm = ->
       StateMachineBuilder!
@@ -249,11 +218,14 @@ spec ->
           \add_transition_to 'state-2'
           \add_transition_to 'state-3'
         \add_state with StateSpec 'state-2'
+          \set_data_type [[{
+            hello: string,
+            world: number,
+            optional: ?string,
+          }]]
           \add_transition_to 'state-1'
-          \add_field 'hello', 'string'
-          \add_field 'world', 'number'
-          \add_field 'optional', '?string'
-        \add_state StateSpec 'state-3'
+        \add_state with StateSpec 'state-3'
+          \set_data_type 'number'
         \build!
 
     it 'rejects new fields', ->
@@ -261,17 +233,27 @@ spec ->
       $expect_that (-> test_sm.foo = 'bar'), errors matches [[cannot add field 'foo' to state machine]]
 
     describe '.state', ->
-      it 'validates changes', ->
+      it 'exposes table data at its toplevel', ->
         test_sm = make_test_sm!
         test_sm\goto 'state-2',
           hello: 'asdf'
-          world: 321
-        $expect_that (-> test_sm.state.hello = 'hello'), no_errors!
-        $expect_that (-> test_sm.state.hello = 123), errors matches 'incorrect type: expected string but got number'
+          world: 4321
+        $expect_that test_sm.state.hello, eq 'asdf'
+        $expect_that test_sm.state.world, eq 4321
 
-      it 'rejects new fields', ->
+      it 'exposes non-table data in the .data field', ->
         test_sm = make_test_sm!
-        $expect_that (-> test_sm.state.foo = 'bar'), errors matches 'no such field state%-1.foo'
+        test_sm\goto 'state-3', 123
+        $expect_that test_sm.state.value, eq 123
+
+      it 'rejects assignment', ->
+        test_sm = make_test_sm!
+        test_sm\goto 'state-2',
+          hello: 'asdf'
+          world: 4321
+        $expect_that (-> test_sm.state.absent = 'foo'), errors matches 'cannot directly assign state fields'
+        $expect_that (-> test_sm.state.hello = nil), errors matches 'cannot directly assign state fields'
+        $expect_that (-> test_sm.state.hello = 'bar'), errors matches 'cannot directly assign state fields'
 
     describe '\\goto', ->
       it 'requires at least one argument', ->
@@ -292,20 +274,20 @@ spec ->
 
         test_sm\goto 'state-1'
         $expect_that test_sm.state.name, eq 'state-1'
-        $expect_that (-> test_sm.state.hello), errors matches 'no such field state%-1.hello'
-        $expect_that (-> test_sm.state.world), errors matches 'no such field state%-1.world'
-        $expect_that (-> test_sm.state.optional), errors matches 'no such field state%-1.optional'
+        $expect_that test_sm.state.hello, eq nil
+        $expect_that test_sm.state.world, eq nil
+        $expect_that test_sm.state.optional, eq nil
 
       it 'rejects invalid transitions', ->
         test_sm = make_test_sm!
         $expect_that (-> test_sm\goto 'invalid'), errors matches 'no such transition: state%-1 %-> invalid'
 
-        test_sm\goto 'state-3'
+        test_sm\goto 'state-3', 123
         $expect_that (-> test_sm\goto 'state-1'), errors matches 'no such transition: state%-3 %-> state%-1'
 
       it 'rejects transitions with missing data', ->
         test_sm = make_test_sm!
-        $expect_that (-> test_sm\goto 'state-2'), errors matches 'incorrect type: expected [sn][tu][rm][ib][ne][gr] but got nil'
+        $expect_that (-> test_sm\goto 'state-2'), errors matches 'incorrect type: expected table but got nil'
         $expect_that (-> test_sm\goto 'state-2', hello: 'asdf'), errors matches 'incorrect type: expected number but got nil'
         $expect_that (-> test_sm\goto 'state-2', world: 123), errors matches 'incorrect type: expected string but got nil'
 
@@ -315,7 +297,7 @@ spec ->
 
       it 'rejects extra state fields', ->
         test_sm = make_test_sm!
-        $expect_that (-> test_sm\goto 'state-3', spare: 'spare'), errors matches 'no such field state%-3.spare'
+        $expect_that (-> test_sm\goto 'state-3', spare: 'spare'), errors matches 'incorrect type'
 
   describe 'set_reporter', ->
     it 'is respected by state machines', ->
@@ -328,8 +310,10 @@ spec ->
           \add_transition_to 'state-2'
         \add_state with StateSpec 'state-2'
           \add_transition_to 'state-1'
-          \add_field 'hello', 'string'
-          \add_field 'world', 'number'
+          \set_data_type [[{
+            hello: string,
+            world: number
+          }]]
         \build!
 
       data =
@@ -346,7 +330,7 @@ spec ->
       test_sm\goto 'state-1'
       test_sm\goto 'state-2', data
 
-      $expect_that [ state.<index> for state in *states ], deep_eq
+      $expect_that [ state for state in *states ], deep_eq
         * { name: 'state-2', ...data }
         * { name: 'state-1' }
         * { name: 'state-2', ...data }

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -92,6 +92,14 @@ function_type = (type_spec) ->
     function_types[type_spec] = parsed_type
     parsed_type
 
+export is_valid_type_spec = (type_spec) ->
+  ret = true
+  try
+    parse type_spec
+  catch _
+    ret = false
+  ret
+
 parse = (type_spec) ->
   type_spec_parser = TypeSpecParser Lexer type_spec
   type_spec_parser\parse!
@@ -1796,3 +1804,12 @@ spec ->
       $expect_that stats_arr, each_value has_fields count: ge 0
 
       COLLECT_STATS = prev_collect_stats
+
+  describe 'is_valid_type_spec', ->
+    it 'returns true on valid type specs', ->
+      $expect_that (is_valid_type_spec 'number'), eq true
+
+    it 'returns false on invalid type specs', ->
+      $expect_that (is_valid_type_spec 'unknown'), eq false
+      $expect_that (is_valid_type_spec '('), eq false
+      $expect_that (is_valid_type_spec ')'), eq false


### PR DESCRIPTION
This PR makes use of `quicktype` types to specify state data. It also adds a notion of _end_ states---a state machine must be in an end state when the `.end` method is called. It also validates reachability conditions.
